### PR TITLE
Configure Dependabot for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development


### PR DESCRIPTION
Updated Dependabot configuration to specify npm as the package ecosystem and removed unnecessary comments.
