### PR TITLE
refactor: remove redundant section marker comments

### DIFF
--- a/src/api/depsdev.ts
+++ b/src/api/depsdev.ts
@@ -13,10 +13,6 @@ import type { Ecosystem } from "../types/index.js";
 
 const BASE_URL = "https://api.deps.dev/v3";
 
-// ---------------------------------------------------------------------------
-// Ecosystem name mapping (our lowercase → deps.dev uppercase)
-// ---------------------------------------------------------------------------
-
 const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   npm: "npm",
   pypi: "pypi",
@@ -26,10 +22,6 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   nuget: "nuget",
   rubygems: "rubygems",
 };
-
-// ---------------------------------------------------------------------------
-// Raw API response types (mirrors the actual API shape)
-// ---------------------------------------------------------------------------
 
 export interface DepsDevVersionKey {
   system: string;
@@ -123,10 +115,6 @@ export interface DepsDevAdvisory {
   cvss3Vector: string;
 }
 
-// ---------------------------------------------------------------------------
-// HTTP helper
-// ---------------------------------------------------------------------------
-
 async function get<T>(path: string): Promise<T> {
   const url = `${BASE_URL}${path}`;
   const res = await fetch(url, {
@@ -151,10 +139,6 @@ export class DepsDevError extends Error {
     this.name = "DepsDevError";
   }
 }
-
-// ---------------------------------------------------------------------------
-// Public API functions
-// ---------------------------------------------------------------------------
 
 /**
  * Get metadata for a specific package version.

--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -12,10 +12,6 @@ import type { Ecosystem, Severity } from "../types/index.js";
 
 const BASE_URL = "https://api.osv.dev/v1";
 
-// ---------------------------------------------------------------------------
-// Ecosystem name mapping (our lowercase → OSV convention)
-// ---------------------------------------------------------------------------
-
 const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   npm: "npm",
   pypi: "PyPI",
@@ -25,10 +21,6 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   nuget: "NuGet",
   rubygems: "RubyGems",
 };
-
-// ---------------------------------------------------------------------------
-// Raw API response types (mirrors the actual OSV API shape)
-// ---------------------------------------------------------------------------
 
 export interface OsvSeverityEntry {
   type: "CVSS_V2" | "CVSS_V3" | "CVSS_V4";
@@ -85,10 +77,6 @@ export interface OsvBatchResponse {
   results: OsvQueryResponse[];
 }
 
-// ---------------------------------------------------------------------------
-// HTTP helpers
-// ---------------------------------------------------------------------------
-
 async function post<TResponse>(path: string, body: unknown): Promise<TResponse> {
   const url = `${BASE_URL}${path}`;
   const res = await fetch(url, {
@@ -118,10 +106,6 @@ export class OsvError extends Error {
     this.name = "OsvError";
   }
 }
-
-// ---------------------------------------------------------------------------
-// Public API functions
-// ---------------------------------------------------------------------------
 
 /**
  * Query vulnerabilities for a single package@version.
@@ -181,10 +165,6 @@ export async function getVuln(vulnId: string): Promise<OsvVuln> {
 
   return res.json() as Promise<OsvVuln>;
 }
-
-// ---------------------------------------------------------------------------
-// Severity helpers
-// ---------------------------------------------------------------------------
 
 /**
  * Extract a human-readable severity level from an OSV vulnerability.
@@ -248,10 +228,6 @@ export function extractFixVersions(vuln: OsvVuln, ecosystem: Ecosystem): string[
 
   return [...fixed];
 }
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 function parseCvssScore(vector: string): number | null {
   // CVSS vectors look like "CVSS:3.1/AV:N/AC:L/..." — the base score is not

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -2,9 +2,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
 
 export function registerPrompts(server: McpServer): void {
-  // ---------------------------------------------------------------------------
-  // security_audit — full project security audit workflow
-  // ---------------------------------------------------------------------------
   server.registerPrompt(
     "security_audit",
     {
@@ -46,9 +43,6 @@ Summarize findings as:
     },
   );
 
-  // ---------------------------------------------------------------------------
-  // package_evaluation — evaluate a candidate package before adding it
-  // ---------------------------------------------------------------------------
   server.registerPrompt(
     "package_evaluation",
     {
@@ -89,9 +83,6 @@ Give me a clear **GO / NO-GO / CONDITIONAL** recommendation with reasoning. If c
     },
   );
 
-  // ---------------------------------------------------------------------------
-  // pre_release_check — dependency scan before shipping
-  // ---------------------------------------------------------------------------
   server.registerPrompt(
     "pre_release_check",
     {

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -97,7 +97,6 @@ export function register(server: McpServer) {
           const grade = scorecardGrade(projectData.scorecard.overallScore);
           lines.push(`🏆 OpenSSF Scorecard: ${score}/10 (${grade})`);
 
-          // Show weakest checks
           const weak = [...projectData.scorecard.checks]
             .sort((a, b) => a.score - b.score)
             .slice(0, 3);

--- a/src/tools/popular.ts
+++ b/src/tools/popular.ts
@@ -94,7 +94,6 @@ export function register(server: McpServer) {
         };
       }
 
-      // Fetch the default version for each package
       const packageResults = await Promise.allSettled(
         names.map(async (name) => {
           const pkg = await getPackage(eco, name);
@@ -115,7 +114,6 @@ export function register(server: McpServer) {
 
       const failed = packageResults.filter((r) => r.status === "rejected").length;
 
-      // Batch query vulns for all resolved packages
       const vulnResults = await queryVulnsBatch(
         resolved.map((p) => ({ ecosystem: eco, name: p.name, version: p.version })),
       );


### PR DESCRIPTION
Remove self-evident separator comments (HTTP helper, Public API functions, etc.) and inline comments that restate what the code already says clearly. Genuinely useful comments (algorithm docs, non-obvious behavior) are kept.

