### PR TITLE
remove hound prefix from tool names

### DIFF
--- a/src/tools/advisories.ts
+++ b/src/tools/advisories.ts
@@ -5,7 +5,7 @@ import { getVuln } from "../api/osv.js";
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_advisories",
+    "advisories",
     {
       description:
         "Get full details for a security advisory by ID (GHSA, CVE, or OSV ID). Returns title, severity, affected versions, fix versions, and references.",

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -18,7 +18,7 @@ const SEVERITY_ICON: Record<string, string> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_audit",
+    "audit",
     {
       description:
         "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, or go.sum and batch-queries OSV for vulnerabilities across all dependencies.",

--- a/src/tools/compare.ts
+++ b/src/tools/compare.ts
@@ -92,7 +92,7 @@ function winner(a: number, b: number, higherIsBetter = true): [string, string] {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_compare",
+    "compare",
     {
       description:
         "Side-by-side comparison of two packages: vulnerabilities, OpenSSF Scorecard, GitHub stars, release recency, and license. Returns a recommendation.",

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -8,7 +8,7 @@ const ECOSYSTEM_VALUES = ["npm", "pypi", "go", "maven", "cargo", "nuget", "rubyg
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_inspect",
+    "inspect",
     {
       description:
         "Get a comprehensive profile of a package version: licenses, vulnerabilities, OpenSSF scorecard, GitHub stats, and dependency count — all in one call.",

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -46,7 +46,7 @@ const MAX_FETCH = 50;
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_license_check",
+    "license_check",
     {
       description:
         "Scan a lockfile for license compliance. Resolves licenses for every dependency and flags packages that violate the chosen policy (permissive, copyleft, or none).",

--- a/src/tools/popular.ts
+++ b/src/tools/popular.ts
@@ -62,7 +62,7 @@ const POPULAR_DEFAULTS: Record<string, string[]> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_popular",
+    "popular",
     {
       description:
         "Scan a list of popular (or user-specified) packages for known vulnerabilities. Quickly surface which widely-used packages in an ecosystem have open security issues.",

--- a/src/tools/preinstall.ts
+++ b/src/tools/preinstall.ts
@@ -16,7 +16,7 @@ const COPYLEFT_LICENSES = new Set([
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_preinstall",
+    "preinstall",
     {
       description:
         "Safety check before installing a package. Checks known vulnerabilities, typosquatting risk, abandonment, and license concerns. Returns a go/no-go verdict.",

--- a/src/tools/score.ts
+++ b/src/tools/score.ts
@@ -48,7 +48,7 @@ function gradeEmoji(grade: string): string {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_score",
+    "score",
     {
       description:
         "Compute a 0-100 Hound Score for a package version combining vulnerability severity, OpenSSF Scorecard, release recency, and license risk. Returns a letter grade (A-F) with a breakdown.",

--- a/src/tools/tree.ts
+++ b/src/tools/tree.ts
@@ -7,7 +7,7 @@ const ECOSYSTEM_VALUES = ["npm", "pypi", "go", "maven", "cargo", "nuget", "rubyg
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_tree",
+    "tree",
     {
       description:
         "Show the full resolved dependency tree for a package version, including all transitive dependencies with their depth and relation type.",

--- a/src/tools/typosquat.ts
+++ b/src/tools/typosquat.ts
@@ -53,7 +53,7 @@ function generateTypos(name: string): string[] {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_typosquat",
+    "typosquat",
     {
       description:
         "Check if a package name looks like a typosquat of a popular package. Generates likely typo variants and checks which ones exist in the registry.",

--- a/src/tools/upgrade.ts
+++ b/src/tools/upgrade.ts
@@ -22,7 +22,7 @@ function compareVersions(a: string, b: string): number {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_upgrade",
+    "upgrade",
     {
       description:
         "Find the minimum version upgrade that resolves all known vulnerabilities for a package. Checks every published version and returns the nearest safe one.",

--- a/src/tools/vulns.ts
+++ b/src/tools/vulns.ts
@@ -15,7 +15,7 @@ const SEVERITY_ICON: Record<string, string> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_vulns",
+    "vulns",
     {
       description:
         "List all known vulnerabilities for a specific package version, grouped by severity with fix versions and advisory links.",


### PR DESCRIPTION
hey, i noticed the tools had the hound prefix which was causing double prefixing in mcp clients like cursor. removed the prefix from all tool names so they just show as the tool name now. let me know if you need anything else!