### PR TITLE
add coverage thresholds to ci workflow

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
       reporter: ["text", "lcov"],
       include: ["src/**/*.ts"],
       exclude: ["src/index.ts"],
+      thresholds: {
+        statements: 75,
+        branches: 55,
+        functions: 80,
+        lines: 75,
+      },
     },
   },
 });


### PR DESCRIPTION
hey, saw the issue about adding coverage thresholds. went ahead and added them to the vitest config.

set the thresholds slightly below current coverage to be safe:
- statements: 75%
- branches: 55%  
- functions: 80%
- lines: 75%

the existing test script will now fail if coverage drops below these. let me know if you want the thresholds adjusted higher!