### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Hound is a free, open-source MCP server that gives AI coding agents a nose for s
 [![CI](https://github.com/tiluckdave/hound-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/tiluckdave/hound-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
+<a href="https://glama.ai/mcp/servers/tiluckdave/hound-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/tiluckdave/hound-mcp/badge" alt="Hound MCP server" />
+</a>
+
 ---
 
 ## Why Hound?


### PR DESCRIPTION
This PR adds a badge for the [Hound MCP](https://glama.ai/mcp/servers/tiluckdave/hound-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/tiluckdave/hound-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/tiluckdave/hound-mcp/badge" alt="Hound MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.