### PR TITLE
chore: exclude examples directory from dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    exclude-paths:
+      - "examples/**"
     groups:
       dev-dependencies:
         dependency-type: development


### PR DESCRIPTION
## What does this PR do?

Adds `exclude-paths` to the Dependabot config so the `examples/` directory is skipped during dependency scans.

## Why?

Example projects have their own dependencies that don't need automated updates from the root repo's Dependabot config.

## Type of change

- [x] CI / tooling

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [ ] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed

## Testing

Config change only — no runtime behavior affected.
