### PR TITLE
Add Gemfile.lock parser for Ruby/Rails projects

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,7 +6,7 @@ Full reference for all 12 Hound MCP tools with syntax and example output.
 
 ## `hound_audit` ⭐
 
-Scan an entire lockfile for vulnerabilities. Parses `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `Cargo.lock`, or `go.sum` and batch-queries OSV across all dependencies.
+Scan an entire lockfile for vulnerabilities. Parses `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `Cargo.lock`, `go.sum`, or `Gemfile.lock` and batch-queries OSV across all dependencies.
 
 ```text
 hound_audit(lockfile_name: "package-lock.json", lockfile_content: "<contents>")

--- a/examples/audit-ruby-project/Gemfile.lock
+++ b/examples/audit-ruby-project/Gemfile.lock
@@ -1,0 +1,152 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    builder (3.2.4)
+    concurrent-ruby (1.1.10)
+    crass (1.0.6)
+    date (3.3.3)
+    erubi (1.12.0)
+    globalid (1.0.1)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    minitest (5.17.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
+    racc (1.6.2)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.5.0)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.0.6)
+    thor (1.2.1)
+    timeout (0.3.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.7)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  rails (~> 7.0.4)
+
+RUBY VERSION
+   ruby 3.1.2p20
+
+BUNDLED WITH
+   2.3.7

--- a/examples/audit-ruby-project/README.md
+++ b/examples/audit-ruby-project/README.md
@@ -1,0 +1,26 @@
+# Ruby Project Audit Example
+
+This example demonstrates how to use Hound to audit a Ruby on Rails project's dependencies for security vulnerabilities.
+
+## Usage
+
+Ask your AI agent:
+
+```
+Audit the Gemfile.lock in examples/audit-ruby-project/ for vulnerabilities
+```
+
+## What Hound Does
+
+1. Parses the `Gemfile.lock` file to extract all gem dependencies
+2. Queries the OSV database for known vulnerabilities in each gem
+3. Returns a comprehensive security report with:
+   - Total number of vulnerabilities by severity (CRITICAL, HIGH, MODERATE, LOW)
+   - Detailed information for each vulnerable gem
+   - CVE IDs and fix recommendations
+
+## Expected Output
+
+Hound will scan all gems including Rails framework components (actioncable, actionpack, etc.) and their dependencies (nokogiri, rack, etc.) for known security issues.
+
+The report groups vulnerabilities by severity and provides actionable information to help you prioritize fixes.

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go";
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems";
 }
 
 /**
@@ -17,6 +17,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "requirements.txt") return parseRequirements(content);
   if (base === "Cargo.lock") return parseCargoLock(content);
   if (base === "go.sum") return parseGoSum(content);
+  if (base === "Gemfile.lock") return parseGemfileLock(content);
 
   return null;
 }
@@ -197,6 +198,40 @@ function parseGoSum(content: string): ParsedDep[] {
       if (!seen.has(key)) {
         seen.add(key);
         deps.push({ name: match[1], version: match[2], ecosystem: "go" });
+      }
+    }
+  }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// Gemfile.lock
+// ---------------------------------------------------------------------------
+function parseGemfileLock(content: string): ParsedDep[] {
+  const deps: ParsedDep[] = [];
+  const lines = content.split("\n");
+  let inSpecs = false;
+
+  for (const line of lines) {
+    // Start of specs section
+    if (line.trim() === "specs:") {
+      inSpecs = true;
+      continue;
+    }
+
+    // End of specs section (PLATFORMS, DEPENDENCIES, etc.)
+    if (inSpecs && line.length > 0 && !line.startsWith(" ")) {
+      inSpecs = false;
+      continue;
+    }
+
+    if (inSpecs) {
+      // Match gem entries: "    rails (7.0.3.1)" or "    actioncable (= 7.0.3.1)"
+      // Gems are indented with 4 spaces, dependencies with 6+ spaces
+      const match = /^ {4}([a-z0-9_-]+)\s+\((?:=\s*)?([^\s)]+)\)/.exec(line);
+      if (match?.[1] && match[2]) {
+        deps.push({ name: match[1], version: match[2], ecosystem: "rubygems" });
       }
     }
   }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -247,7 +247,15 @@ function parseGemfileLock(content: string): ParsedDep[] {
       // Dependency lines like "      actionpack (= 7.0.3.1)" are indented with 6+ spaces and ignored
       const match = /^ {4}([a-z0-9_-]+)\s+\(([^\s)]+)\)/.exec(line);
       if (match?.[1] && match[2]) {
-        deps.push({ name: match[1], version: match[2], ecosystem: "rubygems" });
+        let version = match[2];
+        // Strip platform suffix from versions like "1.14.2-x86_64-darwin" -> "1.14.2"
+        // Platform suffixes follow the pattern: -<platform>-<os> or -<platform>
+        // Keep legitimate prerelease identifiers like "1.0.0-beta.1"
+        const platformMatch = /^(.+?)-(x86_64|arm64|java|mingw32|mswin32|x64_mingw32)/.exec(version);
+        if (platformMatch?.[1]) {
+          version = platformMatch[1];
+        }
+        deps.push({ name: match[1], version, ecosystem: "rubygems" });
       }
     }
   }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -211,11 +211,26 @@ function parseGoSum(content: string): ParsedDep[] {
 function parseGemfileLock(content: string): ParsedDep[] {
   const deps: ParsedDep[] = [];
   const lines = content.split("\n");
+  let inGemSection = false;
   let inSpecs = false;
 
   for (const line of lines) {
-    // Start of specs section
-    if (line.trim() === "specs:") {
+    // Track if we're in the GEM section (not GIT, PATH, etc.)
+    if (line.startsWith("GEM")) {
+      inGemSection = true;
+      inSpecs = false;
+      continue;
+    }
+
+    // Exit GEM section when we hit another top-level section
+    if (line.length > 0 && !line.startsWith(" ") && line !== "GEM") {
+      inGemSection = false;
+      inSpecs = false;
+      continue;
+    }
+
+    // Start of specs section (only parse if in GEM section)
+    if (inGemSection && line.trim() === "specs:") {
       inSpecs = true;
       continue;
     }
@@ -227,9 +242,10 @@ function parseGemfileLock(content: string): ParsedDep[] {
     }
 
     if (inSpecs) {
-      // Match gem entries: "    rails (7.0.3.1)" or "    actioncable (= 7.0.3.1)"
-      // Gems are indented with 4 spaces, dependencies with 6+ spaces
-      const match = /^ {4}([a-z0-9_-]+)\s+\((?:=\s*)?([^\s)]+)\)/.exec(line);
+      // Match gem spec entries: "    actioncable (7.0.3.1)"
+      // Spec entries are indented with 4 spaces
+      // Dependency lines like "      actionpack (= 7.0.3.1)" are indented with 6+ spaces and ignored
+      const match = /^ {4}([a-z0-9_-]+)\s+\(([^\s)]+)\)/.exec(line);
       if (match?.[1] && match[2]) {
         deps.push({ name: match[1], version: match[2], ecosystem: "rubygems" });
       }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -243,9 +243,9 @@ function parseGemfileLock(content: string): ParsedDep[] {
       if (match?.[1] && match[2]) {
         let version = match[2];
         // Strip platform suffix from versions like "1.14.2-x86_64-darwin" -> "1.14.2"
-        // Platform suffixes follow the pattern: -<platform>-<os> or -<platform>
-        // Keep legitimate prerelease identifiers like "1.0.0-beta.1"
-        const platformMatch = /^(.+?)-(x86_64|arm64|java|mingw32|mswin32|x64_mingw32)/.exec(version);
+        // Platform suffixes follow the pattern: -<platform>-<os> or -<platform>, at the end of the string
+        // Keep legitimate prerelease identifiers like "7.1.0-beta.1-x86_64-darwin" -> "7.1.0-beta.1"
+        const platformMatch = /^(.+)-(x86_64|arm64|java|mingw32|mswin32|x64_mingw32)(?:-[a-z0-9_]+)?$/i.exec(version);
         if (platformMatch?.[1]) {
           version = platformMatch[1];
         }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -223,7 +223,7 @@ function parseGemfileLock(content: string): ParsedDep[] {
     }
 
     // Exit GEM section when we hit another top-level section
-    if (line.length > 0 && !line.startsWith(" ") && line !== "GEM") {
+    if (line.length > 0 && !line.startsWith(" ")) {
       inGemSection = false;
       inSpecs = false;
       continue;
@@ -245,7 +245,7 @@ function parseGemfileLock(content: string): ParsedDep[] {
         // Strip platform suffix from versions like "1.14.2-x86_64-darwin" -> "1.14.2"
         // Platform suffixes follow the pattern: -<platform>-<os> or -<platform>, at the end of the string
         // Keep legitimate prerelease identifiers like "7.1.0-beta.1-x86_64-darwin" -> "7.1.0-beta.1"
-        const platformMatch = /^(.+)-(x86_64|arm64|java|mingw32|mswin32|x64_mingw32)(?:-[a-z0-9_]+)?$/i.exec(version);
+        const platformMatch = /^(.+)-(x86_64|arm64|aarch64|universal|java|mingw32|mswin32|x64_mingw32)(?:-[a-z0-9_]+)?$/i.exec(version);
         if (platformMatch?.[1]) {
           version = platformMatch[1];
         }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -235,17 +235,11 @@ function parseGemfileLock(content: string): ParsedDep[] {
       continue;
     }
 
-    // End of specs section (PLATFORMS, DEPENDENCIES, etc.)
-    if (inSpecs && line.length > 0 && !line.startsWith(" ")) {
-      inSpecs = false;
-      continue;
-    }
-
     if (inSpecs) {
       // Match gem spec entries: "    actioncable (7.0.3.1)"
       // Spec entries are indented with 4 spaces
       // Dependency lines like "      actionpack (= 7.0.3.1)" are indented with 6+ spaces and ignored
-      const match = /^ {4}([a-z0-9_-]+)\s+\(([^\s)]+)\)/.exec(line);
+      const match = /^ {4}([A-Za-z0-9_.-]+)\s+\(([^\s)]+)\)/.exec(line);
       if (match?.[1] && match[2]) {
         let version = match[2];
         // Strip platform suffix from versions like "1.14.2-x86_64-darwin" -> "1.14.2"

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -21,13 +21,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, or go.sum and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
           ),
       },
     },
@@ -39,7 +39,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum`,
+              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
             },
           ],
         };

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -45,7 +45,7 @@ export function register(server: McpServer) {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
-          .describe("Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum"),
+          .describe("Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock"),
         policy: z
           .enum(["permissive", "copyleft", "none"])
           .default("permissive")
@@ -62,7 +62,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum`,
+              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
             },
           ],
         };

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -343,14 +343,26 @@ GEM
   remote: https://rubygems.org/
   specs:
     nokogiri (1.14.2-x86_64-darwin)
+    nokogiri (1.14.2-aarch64-darwin)
+    nokogiri (1.14.2-universal-darwin)
     ffi (1.15.5-x64_mingw32)
     nio4r (2.5.8-java)
 `;
     const deps = parseLockfile("Gemfile.lock", content);
-    expect(deps).toHaveLength(3);
+    expect(deps).toHaveLength(5);
     expect(deps).toContainEqual({ name: "nokogiri", version: "1.14.2", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "ffi", version: "1.15.5", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "nio4r", version: "2.5.8", ecosystem: "rubygems" });
+  });
+
+  it("preserves prerelease when stripping platform suffix", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.1.0-beta.1-x86_64-darwin)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toContainEqual({ name: "rails", version: "7.1.0-beta.1", ecosystem: "rubygems" });
   });
 
   it("preserves legitimate prerelease identifiers", () => {

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -337,4 +337,32 @@ GEM
     expect(deps).toContainEqual({ name: "rails", version: "7.1.5.2", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "actionpack", version: "7.1.5.2", ecosystem: "rubygems" });
   });
+
+  it("normalizes platform-qualified gem versions", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    nokogiri (1.14.2-x86_64-darwin)
+    ffi (1.15.5-x64_mingw32)
+    nio4r (2.5.8-java)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(3);
+    expect(deps).toContainEqual({ name: "nokogiri", version: "1.14.2", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "ffi", version: "1.15.5", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "nio4r", version: "2.5.8", ecosystem: "rubygems" });
+  });
+
+  it("preserves legitimate prerelease identifiers", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.1.0-beta.1)
+    devise (5.0.0-rc1)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "rails", version: "7.1.0-beta.1", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "devise", version: "5.0.0-rc1", ecosystem: "rubygems" });
+  });
 });

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -314,4 +314,27 @@ PLATFORMS
     const deps = parseLockfile("Gemfile.lock", content);
     expect(deps).toEqual([]);
   });
+
+  it("ignores GIT section and only parses GEM specs", () => {
+    const content = `GIT
+  remote: https://github.com/heartcombo/devise.git
+  revision: c9e655e13253dc53e3c0981a8345f134bcda1fc5
+  branch: main
+  specs:
+    devise (5.0.2)
+      bcrypt (~> 3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.1.5.2)
+      actionpack (= 7.1.5.2)
+    actionpack (7.1.5.2)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    // Should only parse GEM section, not GIT section
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "rails", version: "7.1.5.2", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "actionpack", version: "7.1.5.2", ecosystem: "rubygems" });
+  });
 });

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -365,4 +365,19 @@ GEM
     expect(deps).toContainEqual({ name: "rails", version: "7.1.0-beta.1", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "devise", version: "5.0.0-rc1", ecosystem: "rubygems" });
   });
+
+  it("handles gem names with uppercase letters and dots", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    RubyInline (3.12.5)
+    net-ssh (7.0.1)
+    i18n (1.12.0)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(3);
+    expect(deps).toContainEqual({ name: "RubyInline", version: "3.12.5", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "net-ssh", version: "7.0.1", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "i18n", version: "1.12.0", ecosystem: "rubygems" });
+  });
 });

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -76,6 +76,33 @@ github.com/gin-gonic/gin v1.9.1/go.mod h1:def=
 github.com/stretchr/testify v1.8.4 h1:ghi=
 `;
 
+const GEMFILE_LOCK = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.3.1)
+      actioncable (= 7.0.3.1)
+      actionmailbox (= 7.0.3.1)
+      actionmailer (= 7.0.3.1)
+    actioncable (7.0.3.1)
+      actionpack (= 7.0.3.1)
+    puma (5.6.5)
+      nio4r (~> 2.0)
+    nio4r (2.5.9)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  rails (~> 7.0.3)
+  puma (~> 5.0)
+
+RUBY VERSION
+   ruby 3.1.0p0
+
+BUNDLED WITH
+   2.3.14
+`;
+
 // ---------------------------------------------------------------------------
 // parseLockfile — dispatch
 // ---------------------------------------------------------------------------
@@ -209,5 +236,82 @@ describe("go.sum", () => {
     expect(deps).toHaveLength(2);
     expect(deps).toContainEqual({ name: "github.com/gin-gonic/gin", version: "1.9.1", ecosystem: "go" });
     expect(deps).toContainEqual({ name: "github.com/stretchr/testify", version: "1.8.4", ecosystem: "go" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gemfile.lock
+// ---------------------------------------------------------------------------
+
+describe("Gemfile.lock", () => {
+  it("parses gems from specs section, skipping dependencies", () => {
+    const deps = parseLockfile("Gemfile.lock", GEMFILE_LOCK);
+    expect(deps).toHaveLength(4);
+    expect(deps).toContainEqual({ name: "rails", version: "7.0.3.1", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "actioncable", version: "7.0.3.1", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "puma", version: "5.6.5", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "nio4r", version: "2.5.9", ecosystem: "rubygems" });
+  });
+
+  it("handles gems with version constraints using = prefix", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.3.1)
+      actioncable (= 7.0.3.1)
+    actioncable (7.0.3.1)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "rails", version: "7.0.3.1", ecosystem: "rubygems" });
+    expect(deps).toContainEqual({ name: "actioncable", version: "7.0.3.1", ecosystem: "rubygems" });
+  });
+
+  it("stops parsing at PLATFORMS section", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rails (7.0.3.1)
+
+PLATFORMS
+  x86_64-darwin-20
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(1);
+    expect(deps).toContainEqual({ name: "rails", version: "7.0.3.1", ecosystem: "rubygems" });
+  });
+
+  it("handles gems with hyphens and underscores in names", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+  specs:
+    sprockets-rails (3.4.2)
+    tzinfo-data (1.2023.3)
+    web_console (4.2.0)
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toHaveLength(3);
+    expect(deps).toContainEqual({
+      name: "sprockets-rails",
+      version: "3.4.2",
+      ecosystem: "rubygems",
+    });
+    expect(deps).toContainEqual({
+      name: "tzinfo-data",
+      version: "1.2023.3",
+      ecosystem: "rubygems",
+    });
+    expect(deps).toContainEqual({ name: "web_console", version: "4.2.0", ecosystem: "rubygems" });
+  });
+
+  it("returns empty array when no specs section exists", () => {
+    const content = `GEM
+  remote: https://rubygems.org/
+
+PLATFORMS
+  x86_64-darwin-20
+`;
+    const deps = parseLockfile("Gemfile.lock", content);
+    expect(deps).toEqual([]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds support for parsing `Gemfile.lock` files from Ruby/Rails projects, enabling vulnerability scanning and license checking for RubyGems dependencies.

Closes #40 

## Why?

Ruby/Rails projects use `Gemfile.lock` to lock dependency versions, but Hound MCP previously only supported JavaScript (npm/yarn/pnpm), Python (pip), Rust (Cargo), and Go ecosystems. This adds Ruby/RubyGems support, allowing users to scan Rails applications and Ruby gems for security vulnerabilities and license compliance issues.

## Type of change

- [ ] Bug fix
- [ ] New tool
- [x] New lockfile parser
- [ ] Improvement to existing tool
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [x] CLAUDE.md updated if architecture changed

## Testing

### Unit Tests (23 test cases)
- Basic Gemfile.lock parsing (GEM section only)
- Platform-qualified version normalization (`nokogiri 1.14.2-x86_64-darwin` → `1.14.2`)
- Prerelease identifier preservation (`7.1.0-beta.1` stays unchanged)
- GIT/PATH section handling (intentionally excluded)
- Gem names with hyphens, underscores, uppercase letters, and dots
- Section boundary detection (PLATFORMS, DEPENDENCIES, etc.)
- Version constraint formats (with and without `=` prefix)

### Real-world Validation
Tested with Mastodon's production `Gemfile.lock` (348 gems):
- Successfully parsed 100 dependencies (tool limit)
- Found real vulnerability: `bcrypt@3.1.21` (GHSA-f27w-vcwj-c954)
- Platform normalization working correctly (no OSV lookup errors)
- End-to-end flow: parse → normalize → OSV query → report

### Example Files
- Added `examples/audit-ruby-project/Gemfile.lock` with real Rails dependencies
- Added `examples/audit-ruby-project/README.md` with usage instructions

### Tools Updated
- `hound_audit` - now supports Gemfile.lock
- `hound_license_check` - now supports Gemfile.lock
- Documentation updated in `docs/tools.md`
