### PR TITLE
Improve unsupported lockfile error messages

### DIFF
--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import { parseLockfile } from "../parsers/index.js";
 import { extractSeverity, queryVulnsBatch } from "../api/osv.js";
 import type { Ecosystem } from "../types/index.js";
+import { formatUnsupportedLockfileMessage } from "../utils/lockfileFormat.js";
 
 const MAX_BATCH = 100; // cap to avoid huge requests
 
@@ -39,7 +40,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
+              text: formatUnsupportedLockfileMessage(lockfile_name),
             },
           ],
         };

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -4,6 +4,7 @@ import { getVersion } from "../api/depsdev.js";
 import { COPYLEFT_LICENSES, NETWORK_COPYLEFT } from "../constants/licenses.js";
 import { parseLockfile } from "../parsers/index.js";
 import type { Ecosystem } from "../types/index.js";
+import { formatUnsupportedLockfileMessage } from "../utils/lockfileFormat.js";
 
 // Licenses allowed under each policy
 const POLICY_ALLOWLISTS: Record<"permissive" | "copyleft", Set<string>> = {
@@ -98,7 +99,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
+              text: formatUnsupportedLockfileMessage(lockfile_name),
             },
           ],
         };

--- a/src/utils/lockfileFormat.ts
+++ b/src/utils/lockfileFormat.ts
@@ -1,0 +1,47 @@
+interface SupportedLockfile {
+  filename: string;
+  ecosystem: string;
+  patterns: string[];
+}
+
+const SUPPORTED_LOCKFILES: SupportedLockfile[] = [
+  { filename: "package-lock.json", ecosystem: "npm", patterns: ["package", "npm"] },
+  { filename: "yarn.lock", ecosystem: "npm/Yarn", patterns: ["yarn"] },
+  { filename: "pnpm-lock.yaml", ecosystem: "npm/pnpm", patterns: ["pnpm"] },
+  { filename: "requirements.txt", ecosystem: "Python/pip", patterns: ["requirements", "pip"] },
+  { filename: "Cargo.lock", ecosystem: "Rust/Cargo", patterns: ["cargo"] },
+  { filename: "go.sum", ecosystem: "Go", patterns: ["go.", "gosum"] },
+  {
+    filename: "Gemfile.lock",
+    ecosystem: "Ruby/Bundler",
+    patterns: ["gemfile", "bundle", "bundler"],
+  },
+];
+
+export function suggestLockfile(input: string): string | null {
+  const normalized = input.toLowerCase();
+
+  for (const { filename, patterns } of SUPPORTED_LOCKFILES) {
+    if (patterns.some((pattern) => normalized.includes(pattern.toLowerCase()))) {
+      return filename;
+    }
+  }
+
+  return null;
+}
+
+export function formatUnsupportedLockfileMessage(input: string): string {
+  const suggestion = suggestLockfile(input);
+  const lines = [`Unsupported lockfile format: ${input}`, ""];
+
+  if (suggestion) {
+    lines.push(`Did you mean: ${suggestion}?`, "");
+  }
+
+  lines.push(
+    "Supported formats:",
+    ...SUPPORTED_LOCKFILES.map(({ filename, ecosystem }) => `  - ${filename} (${ecosystem})`),
+  );
+
+  return lines.join("\n");
+}

--- a/src/utils/lockfileFormat.ts
+++ b/src/utils/lockfileFormat.ts
@@ -5,7 +5,7 @@ interface SupportedLockfile {
 }
 
 const SUPPORTED_LOCKFILES: SupportedLockfile[] = [
-  { filename: "package-lock.json", ecosystem: "npm", patterns: ["package", "npm"] },
+  { filename: "package-lock.json", ecosystem: "npm", patterns: ["package"] },
   { filename: "yarn.lock", ecosystem: "npm/Yarn", patterns: ["yarn"] },
   { filename: "pnpm-lock.yaml", ecosystem: "npm/pnpm", patterns: ["pnpm"] },
   { filename: "requirements.txt", ecosystem: "Python/pip", patterns: ["requirements", "pip"] },

--- a/tests/tools/audit.test.ts
+++ b/tests/tools/audit.test.ts
@@ -87,4 +87,15 @@ describe("hound_audit", () => {
     const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
     expect(text).toContain("Unsupported lockfile format");
   });
+
+  it("suggests a similar supported lockfile format", async () => {
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: "{}",
+      lockfile_name: "package.json",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("Did you mean: package-lock.json?");
+    expect(text).toContain("package-lock.json (npm)");
+  });
 });

--- a/tests/tools/audit.test.ts
+++ b/tests/tools/audit.test.ts
@@ -98,4 +98,14 @@ describe("hound_audit", () => {
     expect(text).toContain("Did you mean: package-lock.json?");
     expect(text).toContain("package-lock.json (npm)");
   });
+
+  it("suggests pnpm-lock.yaml for a pnpm lockfile typo", async () => {
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: "{}",
+      lockfile_name: "pnpm.lock",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("Did you mean: pnpm-lock.yaml?");
+  });
 });

--- a/tests/tools/license-check.test.ts
+++ b/tests/tools/license-check.test.ts
@@ -73,6 +73,18 @@ describe("hound_license_check", () => {
     expect(text).toContain("Unsupported lockfile format");
   });
 
+  it("suggests a similar supported lockfile format", async () => {
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: "{}",
+      lockfile_name: "pip-freeze.txt",
+      policy: "permissive",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("Did you mean: requirements.txt?");
+    expect(text).toContain("requirements.txt (Python/pip)");
+  });
+
   it("reports license distribution summary", async () => {
     vi.mocked(depsdev.getVersion).mockResolvedValue(mockVersion(["Apache-2.0"]));
 


### PR DESCRIPTION
## What does this PR do?

Improves the unsupported lockfile error shown by `hound_audit` and `hound_license_check` by adding:

- a shared formatter for unsupported lockfile messages
- filename suggestions for common near-misses like `package.json` or `pip-freeze.txt`
- ecosystem context for each supported lockfile format
- test coverage for the new suggestion behavior in both tools

Closes #67.

## Why?

The previous error listed supported filenames in one line, but did not help users recover from common mistakes. This makes the message more actionable while keeping tool output human-readable.

## Type of change

- [ ] Bug fix
- [ ] New tool
- [ ] New lockfile parser
- [x] Improvement to existing tool
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [x] CLAUDE.md updated if architecture changed

## Testing

- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm exec eslint src/ tests/`
- `corepack pnpm exec vitest run`

Note: I ran the equivalent commands directly because `pnpm` is only available through Corepack in this environment.
