### PR TITLE
feat(typosquat): add double-character typo generation

### DIFF
--- a/src/tools/typosquat.ts
+++ b/src/tools/typosquat.ts
@@ -28,6 +28,12 @@ function generateTypos(name: string): string[] {
     variants.add(name.slice(0, i) + b + a + name.slice(i + 2));
   }
 
+  // Double each character
+  for (let i = 0; i < name.length; i++) {
+    const char = name[i];
+    variants.add(name.slice(0, i) + char + name.slice(i));
+  }
+
   // Hyphen/underscore confusion
   if (name.includes("-")) {
     variants.add(name.replaceAll("-", "_"));


### PR DESCRIPTION
## Description

This PR enhances the `hound_typosquat` tool to detect double-character typos as requested in #68. 
It correctly simulates the common mistake of accidentally holding a key down for too long (e.g., `lodash` → `llodash` or `loddash`) by systematically duplicating each character position in the original string and appending the results to the variant set.

## Related Issues
Closes #68

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`