### PR TITLE
test: add direct generateTypos coverage

### DIFF
--- a/src/tools/typosquat.ts
+++ b/src/tools/typosquat.ts
@@ -9,7 +9,6 @@ import type { Ecosystem } from "../types/index.js";
  * Covers the most common attack patterns:
  * - character omission (lodsh)
  * - character transposition (lodasg)
- * - character substitution (1odash, l0dash)
  * - hyphen/underscore confusion (lo_dash, lo-dash)
  * - common prefix/suffix additions (node-lodash, lodash-js)
  */

--- a/src/tools/typosquat.ts
+++ b/src/tools/typosquat.ts
@@ -13,12 +13,15 @@ import type { Ecosystem } from "../types/index.js";
  * - hyphen/underscore confusion (lo_dash, lo-dash)
  * - common prefix/suffix additions (node-lodash, lodash-js)
  */
-function generateTypos(name: string): string[] {
+export function generateTypos(name: string): string[] {
   const variants = new Set<string>();
 
   // Omit each character
   for (let i = 0; i < name.length; i++) {
-    variants.add(name.slice(0, i) + name.slice(i + 1));
+    const variant = name.slice(0, i) + name.slice(i + 1);
+    if (variant.length > 0) {
+      variants.add(variant);
+    }
   }
 
   // Transpose adjacent characters

--- a/tests/tools/typosquat.test.ts
+++ b/tests/tools/typosquat.test.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as depsdev from "../../src/api/depsdev.js";
-import { register } from "../../src/tools/typosquat.js";
+import { generateTypos, register } from "../../src/tools/typosquat.js";
 
 vi.mock("../../src/api/depsdev.js");
 
@@ -67,5 +67,51 @@ describe("hound_typosquat", () => {
     )({ name: "myfakepackage", ecosystem: "npm" });
     const text = getText(result);
     expect(text).toContain("does not exist");
+  });
+});
+
+describe("generateTypos", () => {
+  it("generates character omission variants", () => {
+    const variants = generateTypos("lodash");
+
+    expect(variants).toContain("odash");
+    expect(variants).toContain("lodas");
+    expect(variants).toContain("ldash");
+  });
+
+  it("generates character transposition variants", () => {
+    const variants = generateTypos("lodash");
+
+    expect(variants).toContain("oldash");
+    expect(variants).toContain("ldoash");
+  });
+
+  it("generates hyphen and underscore variants", () => {
+    expect(generateTypos("my-package")).toEqual(
+      expect.arrayContaining(["my_package", "mypackage"]),
+    );
+    expect(generateTypos("my_package")).toEqual(
+      expect.arrayContaining(["my-package", "mypackage"]),
+    );
+  });
+
+  it("generates common prefix and suffix variants", () => {
+    const variants = generateTypos("axios");
+
+    expect(variants).toContain("node-axios");
+    expect(variants).toContain("axios-js");
+    expect(variants).toContain("axiosjs");
+  });
+
+  it("does not include the original package name", () => {
+    const variants = generateTypos("lodash");
+
+    expect(variants).not.toContain("lodash");
+  });
+
+  it("does not create an empty variant for single-character names", () => {
+    const variants = generateTypos("x");
+
+    expect(variants).not.toContain("");
   });
 });


### PR DESCRIPTION
## Summary

- export `generateTypos` so it can be unit tested directly
- add coverage for omission, transposition, hyphen/underscore variants, affixes, original-name exclusion, and single-character input
- avoid emitting an empty typo variant for single-character package names

Closes #64

## Testing

- `npx --yes pnpm@10.26.1 test -- tests/tools/typosquat.test.ts`
- `npx --yes pnpm@10.26.1 check`