### PR TITLE
docs: add JSDoc comments to API client functions (#66)

### DIFF
--- a/src/api/depsdev.ts
+++ b/src/api/depsdev.ts
@@ -141,8 +141,20 @@ export class DepsDevError extends Error {
 }
 
 /**
- * Get metadata for a specific package version.
- * Includes licenses, advisory keys, and related project links.
+ * Retrieves metadata for a specific package version from the deps.dev API.
+ *
+ * Includes information such as licenses, advisory references,
+ * related projects, publication date, and version details.
+ *
+ * @param ecosystem - The package ecosystem (npm, pypi, go, maven, cargo, nuget, or rubygems).
+ * @param name - The package name.
+ * @param version - The specific package version to retrieve.
+ * @returns Detailed metadata for the specified package version.
+ * @throws {DepsDevError} When the package version cannot be found or the API request fails.
+ *
+ * @example
+ * const version = await getVersion("npm", "express", "4.18.2");
+ * console.log(version.licenses);
  */
 export async function getVersion(
   ecosystem: Ecosystem,
@@ -156,8 +168,18 @@ export async function getVersion(
 }
 
 /**
- * Get all versions of a package.
- * Useful for finding available upgrade targets.
+ * Retrieves metadata for a package and all available versions.
+ *
+ * Useful for exploring package history and identifying upgrade targets.
+ *
+ * @param ecosystem - The package ecosystem.
+ * @param name - The package name.
+ * @returns Package metadata including version information.
+ * @throws {DepsDevError} When the package cannot be found or the API request fails.
+ *
+ * @example
+ * const pkg = await getPackage("npm", "express");
+ * console.log(pkg.versions.length);
  */
 export async function getPackage(ecosystem: Ecosystem, name: string): Promise<DepsDevPackage> {
   const sys = ECOSYSTEM_MAP[ecosystem];
@@ -165,9 +187,20 @@ export async function getPackage(ecosystem: Ecosystem, name: string): Promise<De
 }
 
 /**
- * Get the full resolved dependency graph for a package version.
- * Returns nodes (packages) and edges (dependency relationships).
- * relationType: SELF = the package itself, DIRECT = direct deps, INDIRECT = transitive deps.
+ * Retrieves the fully resolved dependency graph for a package version.
+ *
+ * The response contains dependency nodes and dependency edges,
+ * allowing traversal of direct and transitive dependencies.
+ *
+ * @param ecosystem - The package ecosystem.
+ * @param name - The package name.
+ * @param version - The package version.
+ * @returns Dependency graph containing nodes and edges.
+ * @throws {DepsDevError} When dependency information cannot be retrieved.
+ *
+ * @example
+ * const deps = await getDependencies("npm", "express", "4.18.2");
+ * console.log(deps.nodes.length);
  */
 export async function getDependencies(
   ecosystem: Ecosystem,
@@ -181,8 +214,19 @@ export async function getDependencies(
 }
 
 /**
- * Get project metadata and OpenSSF Scorecard for a GitHub/GitLab project.
- * projectId format: "github.com/owner/repo"
+ * Retrieves project metadata and OpenSSF Scorecard information.
+ *
+ * Project identifiers are typically source repository paths such as
+ * github.com/owner/repository.
+ *
+ * @param projectId - Project identifier in the format "github.com/owner/repo".
+ * @returns Project metadata including stars, forks, license information,
+ * description, homepage, and scorecard data.
+ * @throws {DepsDevError} When the project cannot be found or the API request fails.
+ *
+ * @example
+ * const project = await getProject("github.com/expressjs/express");
+ * console.log(project.starsCount);
  */
 export async function getProject(projectId: string): Promise<DepsDevProject> {
   const encoded = projectId.replaceAll("/", "%2F");
@@ -190,15 +234,35 @@ export async function getProject(projectId: string): Promise<DepsDevProject> {
 }
 
 /**
- * Get full advisory details by advisory ID (e.g. "GHSA-rv95-896h-c2vc").
+ * Retrieves advisory details from deps.dev using an advisory identifier.
+ *
+ * Advisory records include severity information, aliases,
+ * vulnerability references, and CVSS data.
+ *
+ * @param advisoryId - Advisory identifier such as a GHSA ID.
+ * @returns Advisory details associated with the provided identifier.
+ * @throws {DepsDevError} When the advisory cannot be found or the API request fails.
+ *
+ * @example
+ * const advisory = await getAdvisory("GHSA-rv95-896h-c2vc");
+ * console.log(advisory.title);
  */
 export async function getAdvisory(advisoryId: string): Promise<DepsDevAdvisory> {
   return get<DepsDevAdvisory>(`/advisories/${encodeURIComponent(advisoryId)}`);
 }
 
 /**
- * Extract the GitHub/GitLab project ID from a version's relatedProjects list.
- * Returns the first SOURCE_REPO or ISSUE_TRACKER project ID found, or null.
+ * Extracts a source repository or issue tracker project identifier
+ * from a package version's related projects list.
+ *
+ * The function returns the first SOURCE_REPO or ISSUE_TRACKER entry found.
+ *
+ * @param version - Package version metadata returned by deps.dev.
+ * @returns Project identifier if available; otherwise null.
+ *
+ * @example
+ * const projectId = extractProjectId(version);
+ * console.log(projectId);
  */
 export function extractProjectId(version: DepsDevVersion): string | null {
   const related = version.relatedProjects ?? [];

--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -108,8 +108,17 @@ export class OsvError extends Error {
 }
 
 /**
- * Query vulnerabilities for a single package@version.
- * Returns an empty array if no vulnerabilities are found.
+ * Query vulnerabilities for a specific package version.
+ *
+ * @param ecosystem - Package ecosystem (npm, PyPI, Go, Maven, etc.)
+ * @param name - Package name
+ * @param version - Package version to check
+ * @returns Array of vulnerabilities affecting the package version
+ * @throws {OsvError} When the OSV API request fails
+ *
+ * @example
+ * const vulns = await queryVulns("npm", "express", "4.17.1");
+ * console.log(vulns.length);
  */
 export async function queryVulns(
   ecosystem: Ecosystem,
@@ -127,9 +136,17 @@ export async function queryVulns(
 }
 
 /**
- * Query vulnerabilities for multiple packages in a single API call.
- * Returns results in the same order as the input packages array.
- * Packages with no vulnerabilities return an empty array.
+ * Query vulnerabilities for multiple packages in a single request.
+ *
+ * @param packages - List of package objects containing ecosystem, name, and version
+ * @returns Array of vulnerability arrays in the same order as the input packages
+ * @throws {OsvError} When the OSV API request fails
+ *
+ * @example
+ * const results = await queryVulnsBatch([
+ *   { ecosystem: "npm", name: "express", version: "4.17.1" },
+ *   { ecosystem: "npm", name: "lodash", version: "4.17.20" }
+ * ]);
  */
 export async function queryVulnsBatch(
   packages: { ecosystem: Ecosystem; name: string; version: string }[],
@@ -150,7 +167,15 @@ export async function queryVulnsBatch(
 }
 
 /**
- * Fetch full vulnerability details by OSV/GHSA ID.
+ * Fetch detailed vulnerability information by OSV or GHSA identifier.
+ *
+ * @param vulnId - Vulnerability identifier
+ * @returns Complete vulnerability details
+ * @throws {OsvError} When the vulnerability cannot be found
+ *
+ * @example
+ * const vuln = await getVuln("GHSA-rv95-896h-c2vc");
+ * console.log(vuln.summary);
  */
 export async function getVuln(vulnId: string): Promise<OsvVuln> {
   const url = `${BASE_URL}/vulns/${encodeURIComponent(vulnId)}`;
@@ -167,8 +192,10 @@ export async function getVuln(vulnId: string): Promise<OsvVuln> {
 }
 
 /**
- * Extract a human-readable severity level from an OSV vulnerability.
- * Prefers database_specific.severity, falls back to parsing CVSS score.
+ * Determine the severity level of a vulnerability.
+ *
+ * @param vuln - Vulnerability object returned by the OSV API
+ * @returns Severity level (LOW, MODERATE, HIGH, CRITICAL, or UNKNOWN)
  */
 export function extractSeverity(vuln: OsvVuln): Severity {
   // Prefer the GitHub advisory database severity label
@@ -188,9 +215,10 @@ export function extractSeverity(vuln: OsvVuln): Severity {
 }
 
 /**
- * Extract a numeric CVSS score from an OSV vulnerability.
- * Prefers CVSS_V3, falls back to V4, then V2.
- * Returns null if no CVSS score is available.
+ * Extract the CVSS score from a vulnerability record.
+ *
+ * @param vuln - Vulnerability object
+ * @returns Numeric CVSS score or null if unavailable
  */
 export function extractCvssScore(vuln: OsvVuln): number | null {
   const entries = vuln.severity ?? [];
@@ -206,8 +234,11 @@ export function extractCvssScore(vuln: OsvVuln): number | null {
 }
 
 /**
- * Extract fix versions from an OSV affected range.
- * Returns a deduplicated list of versions that fix the vulnerability.
+ * Extract versions that contain fixes for a vulnerability.
+ *
+ * @param vuln - Vulnerability object
+ * @param ecosystem - Package ecosystem
+ * @returns Array of fixed versions
  */
 export function extractFixVersions(vuln: OsvVuln, ecosystem: Ecosystem): string[] {
   const osvEcosystem = ECOSYSTEM_MAP[ecosystem];


### PR DESCRIPTION
## What does this PR do?

Adds comprehensive JSDoc documentation comments to exported API client functions in:

* `src/api/depsdev.ts`
* `src/api/osv.ts`

The documentation includes descriptions, `@param`, `@returns`, `@throws`, and usage examples where applicable.

## Why?

This improves code readability and developer experience by providing better IDE tooltips, making the codebase easier to understand and maintain for both existing and new contributors.

## Type of change

* [ ] Bug fix
* [ ] New tool
* [ ] New lockfile parser
* [ ] Improvement to existing tool
* [ ] Refactor / cleanup
* [x] Documentation
* [ ] CI / tooling

## Checklist

* [x] `pnpm check` passes (typecheck + lint + tests)
* [ ] New functionality has tests
* [x] Tool output is human-readable text (not raw JSON)
* [x] No new dependencies that require API keys or accounts
* [x] CLAUDE.md updated if architecture changed (Not Applicable)

## Testing

Verified that all existing tests pass successfully after the documentation changes.

Results:

* Test Files: 16 passed
* Tests: 123 passed

The changes are documentation-only and do not modify application logic or functionality.

Fixes #66
