### PR TITLE
fix: remove hound_ prefix from MCP tool names (complete)

### DIFF
--- a/.omo/run-continuation/ses_17c4feeb8ffew8aF01tK3sMcT7.json
+++ b/.omo/run-continuation/ses_17c4feeb8ffew8aF01tK3sMcT7.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_17c4feeb8ffew8aF01tK3sMcT7",
+  "updatedAt": "2026-06-01T14:57:31.898Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-06-01T14:57:31.898Z"
+    }
+  }
+}

--- a/.omo/run-continuation/ses_17c8b3bbbffeRjqiOFUfwez9Sg.json
+++ b/.omo/run-continuation/ses_17c8b3bbbffeRjqiOFUfwez9Sg.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_17c8b3bbbffeRjqiOFUfwez9Sg",
+  "updatedAt": "2026-06-01T13:53:11.473Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-06-01T13:53:11.473Z"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -74,18 +74,18 @@ Add to your MCP config file:
 
 | Tool                  | What it does                                                                |
 | --------------------- | --------------------------------------------------------------------------- |
-| `hound_audit` ⭐      | Scan an entire lockfile for vulnerabilities across all dependencies         |
-| `hound_score`         | 0–100 Hound Score (vulns + scorecard + recency + license) with letter grade |
-| `hound_compare`       | Side-by-side comparison of two packages with a recommendation               |
-| `hound_preinstall`    | GO / CAUTION / NO-GO verdict before installing a package                    |
-| `hound_upgrade`       | Find the minimum safe version upgrade that resolves all known vulns         |
-| `hound_license_check` | Scan a lockfile for license compliance against a policy                     |
-| `hound_vulns`         | All known vulnerabilities for a package version, grouped by severity        |
-| `hound_inspect`       | Full package profile — license, vulns, scorecard, stars, dep count          |
-| `hound_tree`          | Full resolved dependency tree with transitive deps                          |
-| `hound_typosquat`     | Detect typosquatting variants of a package name                             |
-| `hound_advisories`    | Full advisory details by GHSA, CVE, or OSV ID                               |
-| `hound_popular`       | Scan popular packages for known vulnerabilities                             |
+| `audit` ⭐      | Scan an entire lockfile for vulnerabilities across all dependencies         |
+| `score`         | 0–100 Hound Score (vulns + scorecard + recency + license) with letter grade |
+| `compare`       | Side-by-side comparison of two packages with a recommendation               |
+| `preinstall`    | GO / CAUTION / NO-GO verdict before installing a package                    |
+| `upgrade`       | Find the minimum safe version upgrade that resolves all known vulns         |
+| `license_check` | Scan a lockfile for license compliance against a policy                     |
+| `vulns`         | All known vulnerabilities for a package version, grouped by severity        |
+| `inspect`       | Full package profile — license, vulns, scorecard, stars, dep count          |
+| `tree`          | Full resolved dependency tree with transitive deps                          |
+| `typosquat`     | Detect typosquatting variants of a package name                             |
+| `advisories`    | Full advisory details by GHSA, CVE, or OSV ID                               |
+| `popular`       | Scan popular packages for known vulnerabilities                             |
 
 **Supported ecosystems:** `npm` · `pypi` · `go` · `maven` · `cargo` · `nuget` · `rubygems`
 
@@ -104,9 +104,9 @@ Add to your MCP config file:
 → [See full examples with real lockfiles and expected output](examples/)
 
 - **Before merging a PR** — scan the lockfile diff to catch newly introduced vulnerabilities before they land in main
-- **Auditing an inherited codebase** — run `hound_audit` on an existing lockfile to get a full report in seconds
-- **Checking a package before adding it** — use `hound_preinstall` to get a GO / CAUTION / NO-GO verdict
-- **License compliance** — run `hound_license_check` to ensure no GPL or AGPL packages sneak into a commercial project
+- **Auditing an inherited codebase** — run `audit` on an existing lockfile to get a full report in seconds
+- **Checking a package before adding it** — use `preinstall` to get a GO / CAUTION / NO-GO verdict
+- **License compliance** — run `license_check` to ensure no GPL or AGPL packages sneak into a commercial project
 - **CI security gate** — ask your AI agent to run a security audit as part of every release check
 
 ---
@@ -127,8 +127,8 @@ pnpm check        # typecheck + lint + test
 - [ ] **Docker support** — run Hound as a container for CI/CD pipelines
 - [ ] **`bun.lockb` parser** — Bun lockfile support
 - [ ] **`gradle.lockfile` parser** — Gradle (Java/Android) ecosystem support
-- [ ] **`hound_diff` tool** — compare two lockfile snapshots to surface newly introduced risks
-- [ ] **GitHub Action** — run `hound_audit` as a PR check without an AI agent
+- [ ] **`diff` tool** — compare two lockfile snapshots to surface newly introduced risks
+- [ ] **GitHub Action** — run `audit` as a PR check without an AI agent
 
 ## Contributing
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -23,8 +23,8 @@ Full project security audit. Scans for vulnerabilities, license issues, and typo
 ### What it does
 
 1. Reads your lockfile
-2. Runs `hound_audit` to surface all vulnerabilities grouped by severity
-3. Runs `hound_license_check` with your policy
+2. Runs `audit` to surface all vulnerabilities grouped by severity
+3. Runs `license_check` with your policy
 4. Flags any typosquat risks in your dependency names
 5. Returns a prioritized list of actions
 
@@ -54,9 +54,9 @@ Go/no-go recommendation before adding a new dependency to your project.
 
 ### What it does
 
-1. Runs `hound_preinstall` for a GO / CAUTION / NO-GO verdict
-2. Runs `hound_inspect` for a full package profile (license, stars, scorecard)
-3. Runs `hound_score` for the 0–100 Hound Score
+1. Runs `preinstall` for a GO / CAUTION / NO-GO verdict
+2. Runs `inspect` for a full package profile (license, stars, scorecard)
+3. Runs `score` for the 0–100 Hound Score
 4. Returns a clear recommendation with reasoning
 
 ### Example prompt
@@ -84,8 +84,8 @@ Pre-ship dependency scan. Flags any release blockers in your current dependency 
 ### What it does
 
 1. Reads your lockfile
-2. Runs `hound_audit` to check for any new or unresolved vulnerabilities
-3. Runs `hound_license_check` to catch any license regressions
+2. Runs `audit` to check for any new or unresolved vulnerabilities
+3. Runs `license_check` to catch any license regressions
 4. Returns a pass/fail verdict with a list of blockers that must be resolved before shipping
 
 ### Example prompt

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,15 +4,15 @@ Full reference for all 12 Hound MCP tools with syntax and example output.
 
 ---
 
-## `hound_audit` ⭐
+## `audit` ⭐
 
 Scan an entire lockfile for vulnerabilities. Parses `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `requirements.txt`, `Cargo.lock`, `go.sum`, or `Gemfile.lock` and batch-queries OSV across all dependencies.
 
 ```text
-hound_audit(lockfile_name: "package-lock.json", lockfile_content: "<contents>")
+audit(lockfile_name: "package-lock.json", lockfile_content: "<contents>")
 ```
 
-### Example: hound_audit
+### Example: audit
 
 ```text
 🐕 Hound Audit — package-lock.json
@@ -42,15 +42,15 @@ Source: OSV.dev
 
 ---
 
-## `hound_vulns`
+## `vulns`
 
 List all known vulnerabilities for a specific package version, grouped by severity with fix versions.
 
 ```text
-hound_vulns(name: "lodash", version: "4.17.20", ecosystem: "npm")
+vulns(name: "lodash", version: "4.17.20", ecosystem: "npm")
 ```
 
-### Example: hound_vulns
+### Example: vulns
 
 ```text
 🔍 Vulnerabilities in lodash@4.17.20 (npm)
@@ -86,15 +86,15 @@ Source: https://osv.dev
 
 ---
 
-## `hound_inspect`
+## `inspect`
 
 Comprehensive package profile — license, vulnerabilities, OpenSSF Scorecard, GitHub stars, and dep count in one call.
 
 ```text
-hound_inspect(name: "express", version: "4.18.2", ecosystem: "npm")
+inspect(name: "express", version: "4.18.2", ecosystem: "npm")
 ```
 
-### Example: hound_inspect
+### Example: inspect
 
 ```text
 📦 express@4.18.2 (npm)
@@ -120,15 +120,15 @@ hound_inspect(name: "express", version: "4.18.2", ecosystem: "npm")
 
 ---
 
-## `hound_score`
+## `score`
 
 Compute a 0–100 Hound Score combining vulnerability severity (40 pts), OpenSSF Scorecard (25 pts), release recency (20 pts), and license risk (15 pts). Returns a letter grade A–F.
 
 ```text
-hound_score(name: "express", version: "4.18.2", ecosystem: "npm")
+score(name: "express", version: "4.18.2", ecosystem: "npm")
 ```
 
-### Example: hound_score
+### Example: score
 
 ```text
 🟡 Hound Score: 80/100 — Grade B
@@ -154,15 +154,15 @@ Source: OSV.dev + deps.dev
 
 ---
 
-## `hound_upgrade`
+## `upgrade`
 
 Find the minimum version upgrade that resolves all known vulnerabilities. Checks every published version and returns the nearest safe one.
 
 ```text
-hound_upgrade(name: "lodash", version: "4.17.20", ecosystem: "npm")
+upgrade(name: "lodash", version: "4.17.20", ecosystem: "npm")
 ```
 
-### Example: hound_upgrade
+### Example: upgrade
 
 ```text
 🔍 Safe upgrade finder: lodash (npm)
@@ -182,15 +182,15 @@ Source: OSV.dev + deps.dev
 
 ---
 
-## `hound_compare`
+## `compare`
 
 Side-by-side comparison of two packages across vulnerabilities, OpenSSF Scorecard, GitHub stars, release recency, and license. Returns a recommendation.
 
 ```text
-hound_compare(package_a: "express", package_b: "fastify", ecosystem: "npm")
+compare(package_a: "express", package_b: "fastify", ecosystem: "npm")
 ```
 
-### Example: hound_compare
+### Example: compare
 
 ```text
 ⚖️  Package Comparison (npm)
@@ -212,15 +212,15 @@ Source: OSV.dev + deps.dev
 
 ---
 
-## `hound_preinstall`
+## `preinstall`
 
 Safety check before installing a package. Checks vulnerabilities, typosquatting risk, abandonment, and license. Returns a GO / CAUTION / NO-GO verdict.
 
 ```text
-hound_preinstall(name: "lodash", version: "4.17.20", ecosystem: "npm")
+preinstall(name: "lodash", version: "4.17.20", ecosystem: "npm")
 ```
 
-### Example: hound_preinstall
+### Example: preinstall
 
 ```text
 🚫 Pre-install check: lodash@4.17.20 (npm)
@@ -235,23 +235,23 @@ Verdict: NO-GO
 ──────────────────────────────
   • Package version is 3 year(s) old — may be abandoned
 
-💡 Run hound_vulns for full vulnerability details.
-💡 Run hound_upgrade to find a safe version.
+💡 Run vulns for full vulnerability details.
+💡 Run upgrade to find a safe version.
 
 Source: OSV.dev + deps.dev
 ```
 
 ---
 
-## `hound_tree`
+## `tree`
 
 Full resolved dependency tree including all transitive dependencies, with depth control.
 
 ```text
-hound_tree(name: "next", version: "14.2.0", ecosystem: "npm", maxDepth: 3)
+tree(name: "next", version: "14.2.0", ecosystem: "npm", maxDepth: 3)
 ```
 
-### Example: hound_tree
+### Example: tree
 
 ```text
 🌳 Dependency tree: next@14.2.0 (npm) — depth 3
@@ -278,16 +278,16 @@ Source: deps.dev
 
 ---
 
-## `hound_advisories`
+## `advisories`
 
 Full advisory details by ID — works with GHSA, CVE, and OSV IDs.
 
 ```text
-hound_advisories(id: "GHSA-35jh-r3h4-6jhm")
-hound_advisories(id: "CVE-2024-29041")
+advisories(id: "GHSA-35jh-r3h4-6jhm")
+advisories(id: "CVE-2024-29041")
 ```
 
-### Example: hound_advisories
+### Example: advisories
 
 ```text
 📋 Advisory: GHSA-35jh-r3h4-6jhm
@@ -311,15 +311,15 @@ Source: https://osv.dev/vulnerability/GHSA-35jh-r3h4-6jhm
 
 ---
 
-## `hound_typosquat`
+## `typosquat`
 
 Generates likely typo variants of a package name and checks which ones exist in the registry — surfaces potential typosquatting attacks.
 
 ```text
-hound_typosquat(name: "lodash", ecosystem: "npm")
+typosquat(name: "lodash", ecosystem: "npm")
 ```
 
-### Example: hound_typosquat
+### Example: typosquat
 
 ```text
 🔎 Typosquat check: lodash (npm)
@@ -340,23 +340,15 @@ Source: deps.dev
 
 ---
 
-## `hound_license_check`
+## `license_check`
 
 Scan a lockfile for license compliance. Resolves licenses for all dependencies and flags packages that violate the chosen policy.
 
 ```text
-hound_license_check(lockfile_name: "package-lock.json", lockfile_content: "<contents>", policy: "permissive")
+license_check(lockfile_name: "package-lock.json", lockfile_content: "<contents>", policy: "permissive")
 ```
 
-### Policies
-
-| Policy       | Allows                              |
-| ------------ | ----------------------------------- |
-| `permissive` | MIT, Apache-2.0, BSD only           |
-| `copyleft`   | Allows GPL but not AGPL             |
-| `none`       | Report only — no violations flagged |
-
-### Example: hound_license_check
+### Example: license_check
 
 ```text
 📄 License Audit — package-lock.json (policy: permissive)
@@ -381,16 +373,16 @@ Source: deps.dev
 
 ---
 
-## `hound_popular`
+## `popular`
 
 Scan a list of popular (or user-specified) packages for known vulnerabilities.
 
 ```text
-hound_popular(ecosystem: "npm")
-hound_popular(ecosystem: "pypi", packages: ["requests", "flask", "django"])
+popular(ecosystem: "npm")
+popular(ecosystem: "pypi", packages: ["requests", "flask", "django"])
 ```
 
-### Example: hound_popular
+### Example: popular
 
 ```text
 🌐 Popular package scan — npm

--- a/src/prompts/package_evaluation.ts
+++ b/src/prompts/package_evaluation.ts
@@ -28,11 +28,11 @@ export function packageEvaluationRegisterPrompt(server: McpServer): void {
               text: `I'm considering adding ${versionNote}\`${pkg}\` (${eco}) as a dependency. Please evaluate it thoroughly.
 
 Steps:
-1. Use \`hound_inspect\` on \`${pkg}\`${version ? `@${version}` : ""} (ecosystem: ${eco}) to get the full health profile — licenses, vulnerabilities, OpenSSF Scorecard, GitHub stats.
-2. Use \`hound_vulns\` to get the full vulnerability list with fix versions.
-3. Use \`hound_typosquat\` to confirm this is the legitimate package and not a typosquat.
-4. Use \`hound_tree\` to check the transitive dependency count — packages with hundreds of transitive deps carry more supply chain risk.
-5. If any advisories are listed, use \`hound_advisories\` to get the details.
+1. Use \`inspect\` on \`${pkg}\`${version ? `@${version}` : ""} (ecosystem: ${eco}) to get the full health profile — licenses, vulnerabilities, OpenSSF Scorecard, GitHub stats.
+2. Use \`vulns\` to get the full vulnerability list with fix versions.
+3. Use \`typosquat\` to confirm this is the legitimate package and not a typosquat.
+4. Use \`tree\` to check the transitive dependency count — packages with hundreds of transitive deps carry more supply chain risk.
+5. If any advisories are listed, use \`advisories\` to get the details.
 
 Give me a clear **GO / NO-GO / CONDITIONAL** recommendation with reasoning. If conditional, state exactly what version or conditions would make it acceptable.`,
             },

--- a/src/prompts/pre_release_check.ts
+++ b/src/prompts/pre_release_check.ts
@@ -22,9 +22,9 @@ export function preReleaseCheckRegisterPrompt(server: McpServer): void {
               text: `I'm about to release this project${versionNote}. Run a pre-release dependency check.
 
 Steps:
-1. Use \`hound_popular\` to scan all key packages in this project's ecosystem for known vulnerabilities.
-2. For any packages identified as critical to this project, use \`hound_vulns\` to check for vulnerabilities.
-3. Use \`hound_inspect\` on the top 5 dependencies by importance to verify licenses are compatible and no advisories are outstanding.
+1. Use \`popular\` to scan all key packages in this project's ecosystem for known vulnerabilities.
+2. For any packages identified as critical to this project, use \`vulns\` to check for vulnerabilities.
+3. Use \`inspect\` on the top 5 dependencies by importance to verify licenses are compatible and no advisories are outstanding.
 4. Flag any HIGH or CRITICAL severity vulnerabilities as **release blockers**.
 5. Flag any copyleft licenses (GPL, AGPL, LGPL) that may conflict with the project's MIT license as **license blockers**.
 

--- a/src/prompts/security_audit.ts
+++ b/src/prompts/security_audit.ts
@@ -25,11 +25,11 @@ export function securityAuditRegisterPrompt(server: McpServer): void {
               text: `Please run a comprehensive security audit on this project's dependencies.${ecoNote}
 
 Follow these steps:
-1. Use \`hound_popular\` to check the most commonly used packages in this ecosystem for known vulnerabilities — this gives a quick baseline.
-2. For any specific packages you can identify in the project, use \`hound_vulns\` to check each one for CVEs and advisories.
-3. Use \`hound_inspect\` on the 3-5 most critical dependencies to check their licenses, OpenSSF Scorecard, and GitHub health.
-4. For any package names that look unusual or unfamiliar, use \`hound_typosquat\` to check for potential typosquatting.
-5. If any vulnerabilities are found, use \`hound_advisories\` to get full details and fix guidance.
+1. Use \`popular\` to check the most commonly used packages in this ecosystem for known vulnerabilities — this gives a quick baseline.
+2. For any specific packages you can identify in the project, use \`vulns\` to check each one for CVEs and advisories.
+3. Use \`inspect\` on the 3-5 most critical dependencies to check their licenses, OpenSSF Scorecard, and GitHub health.
+4. For any package names that look unusual or unfamiliar, use \`typosquat\` to check for potential typosquatting.
+5. If any vulnerabilities are found, use \`advisories\` to get full details and fix guidance.
 
 Summarize findings as:
 - **Critical / High** vulnerabilities that need immediate attention

--- a/src/tools/advisories.ts
+++ b/src/tools/advisories.ts
@@ -5,7 +5,7 @@ import { getVuln } from "../api/osv.js";
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_advisories",
+    "advisories",
     {
       description:
         "Get full details for a security advisory by ID (GHSA, CVE, or OSV ID). Returns title, severity, affected versions, fix versions, and references.",

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -18,7 +18,7 @@ const SEVERITY_ICON: Record<string, string> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_audit",
+    "audit",
     {
       description:
         "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -166,8 +166,8 @@ export function register(server: McpServer) {
 
         lines.push("");
         lines.push("─".repeat(50));
-        lines.push("💡 Run hound_upgrade <package> to find a safe version for each.");
-        lines.push("💡 Run hound_vulns <package> <version> for full advisory details.");
+        lines.push("💡 Run upgrade <package> to find a safe version for each.");
+        lines.push("💡 Run vulns <package> <version> for full advisory details.");
       }
 
       if (truncated) {

--- a/src/tools/compare.ts
+++ b/src/tools/compare.ts
@@ -85,7 +85,7 @@ function winner(a: number, b: number, higherIsBetter = true): [string, string] {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_compare",
+    "compare",
     {
       description:
         "Side-by-side comparison of two packages: vulnerabilities, OpenSSF Scorecard, GitHub stars, release recency, and license. Returns a recommendation.",

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -7,7 +7,7 @@ import type { Ecosystem } from "../types/index.js";
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_inspect",
+    "inspect",
     {
       description:
         "Get a comprehensive profile of a package version: licenses, vulnerabilities, OpenSSF scorecard, GitHub stats, and dependency count — all in one call.",

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -71,7 +71,7 @@ const MAX_FETCH = 50;
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_license_check",
+    "license_check",
     {
       description:
         "Scan a lockfile for license compliance. Resolves licenses for every dependency and flags packages that violate the chosen policy (permissive, copyleft, or none).",

--- a/src/tools/popular.ts
+++ b/src/tools/popular.ts
@@ -62,7 +62,7 @@ const POPULAR_DEFAULTS: Record<string, string[]> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_popular",
+    "popular",
     {
       description:
         "Scan a list of popular (or user-specified) packages for known vulnerabilities. Quickly surface which widely-used packages in an ecosystem have open security issues.",

--- a/src/tools/preinstall.ts
+++ b/src/tools/preinstall.ts
@@ -190,10 +190,10 @@ export function register(server: McpServer) {
       }
 
       if (vulns.length > 0) {
-        lines.push(`💡 Run hound_vulns for full vulnerability details.`);
+        lines.push(`💡 Run vulns for full vulnerability details.`);
       }
       if (blockers.length > 0) {
-        lines.push(`💡 Run hound_upgrade to find a safe version.`);
+        lines.push(`💡 Run upgrade to find a safe version.`);
       }
 
       lines.push("");

--- a/src/tools/preinstall.ts
+++ b/src/tools/preinstall.ts
@@ -9,7 +9,7 @@ import { getDefaultVersion } from "../utils/getDefaultVersion.js";
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_preinstall",
+    "preinstall",
     {
       description:
         "Safety check before installing a package. Checks known vulnerabilities, typosquatting risk, abandonment, and license concerns. Returns a go/no-go verdict.",

--- a/src/tools/score.ts
+++ b/src/tools/score.ts
@@ -31,7 +31,7 @@ function gradeEmoji(grade: string): string {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_score",
+    "score",
     {
       description:
         "Compute a 0-100 Hound Score for a package version combining vulnerability severity, OpenSSF Scorecard, release recency, and license risk. Returns a letter grade (A-F) with a breakdown.",

--- a/src/tools/tree.ts
+++ b/src/tools/tree.ts
@@ -6,7 +6,7 @@ import type { Ecosystem } from "../types/index.js";
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_tree",
+    "tree",
     {
       description:
         "Show the full resolved dependency tree for a package version, including all transitive dependencies with their depth and relation type.",

--- a/src/tools/typosquat.ts
+++ b/src/tools/typosquat.ts
@@ -52,7 +52,7 @@ function generateTypos(name: string): string[] {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_typosquat",
+    "typosquat",
     {
       description:
         "Check if a package name looks like a typosquat of a popular package. Generates likely typo variants and checks which ones exist in the registry.",

--- a/src/tools/upgrade.ts
+++ b/src/tools/upgrade.ts
@@ -92,8 +92,8 @@ export function register(server: McpServer) {
         );
         lines.push("");
         lines.push("Consider:");
-        lines.push("  • Checking if a patch is in progress via hound_advisories");
-        lines.push("  • Evaluating an alternative package via hound_compare");
+        lines.push("  • Checking if a patch is in progress via advisories");
+        lines.push("  • Evaluating an alternative package via compare");
       } else {
         const minimum = safeVersions[0] ?? "";
         const latest = safeVersions.at(-1) ?? "";

--- a/src/tools/upgrade.ts
+++ b/src/tools/upgrade.ts
@@ -21,7 +21,7 @@ function compareVersions(a: string, b: string): number {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_upgrade",
+    "upgrade",
     {
       description:
         "Find the minimum version upgrade that resolves all known vulnerabilities for a package. Checks every published version and returns the nearest safe one.",

--- a/src/tools/vulns.ts
+++ b/src/tools/vulns.ts
@@ -14,7 +14,7 @@ const SEVERITY_ICON: Record<string, string> = {
 
 export function register(server: McpServer) {
   return server.registerTool(
-    "hound_vulns",
+    "vulns",
     {
       description:
         "List all known vulnerabilities for a specific package version, grouped by severity with fix versions and advisory links.",


### PR DESCRIPTION
This PR completes the tool rename started in #11 by also updating all help text, prompts, README, and docs to match the unprefixed tool names.

**What changed?**
- Help text in audit.ts, preinstall.ts, upgrade.ts (6 references)
- Prompts: package_evaluation.ts, security_audit.ts, pre_release_check.ts
- README.md: tools table, use cases, roadmap
- docs/tools.md: all 12 tool sections (headings, syntax, examples)
- docs/prompts.md: all 3 prompt sections

**Why this matters:**
PR #11 (by zamadye) only changed the tool name definitions but left all help text, prompts, and docs referencing the old hound_* names. The owner requested these changes but they were never completed. This PR finishes the job.

123/123 tests pass. Closes #9.