### PR TITLE
Add pubspec.lock parser support

### DIFF
--- a/src/api/depsdev.ts
+++ b/src/api/depsdev.ts
@@ -21,6 +21,7 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   cargo: "cargo",
   nuget: "nuget",
   rubygems: "rubygems",
+  pub: "pub",
 };
 
 export interface DepsDevVersionKey {

--- a/src/api/depsdev.ts
+++ b/src/api/depsdev.ts
@@ -13,7 +13,7 @@ import type { Ecosystem } from "../types/index.js";
 
 const BASE_URL = "https://api.deps.dev/v3";
 
-const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
+const ECOSYSTEM_MAP: Partial<Record<Ecosystem, string>> = {
   npm: "npm",
   pypi: "pypi",
   go: "go",
@@ -21,8 +21,17 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   cargo: "cargo",
   nuget: "nuget",
   rubygems: "rubygems",
-  pub: "pub",
 };
+
+function getDepsDevSystem(ecosystem: Ecosystem): string {
+  const system = ECOSYSTEM_MAP[ecosystem];
+
+  if (!system) {
+    throw new Error(`deps.dev does not support ecosystem: ${ecosystem}`);
+  }
+
+  return system;
+}
 
 export interface DepsDevVersionKey {
   system: string;
@@ -56,7 +65,10 @@ export interface DepsDevVersion {
 }
 
 export interface DepsDevPackage {
-  packageKey: { system: string; name: string };
+  packageKey: {
+    system: string;
+    name: string;
+  };
   versions: {
     versionKey: DepsDevVersionKey;
     publishedAt: string;
@@ -91,13 +103,18 @@ export interface DepsDevScorecardCheck {
 
 export interface DepsDevScorecard {
   date: string;
-  repository: { name: string; commit: string };
+  repository: {
+    name: string;
+    commit: string;
+  };
   overallScore: number;
   checks: DepsDevScorecardCheck[];
 }
 
 export interface DepsDevProject {
-  projectKey: { id: string };
+  projectKey: {
+    id: string;
+  };
   openIssuesCount: number;
   starsCount: number;
   forksCount: number;
@@ -108,7 +125,9 @@ export interface DepsDevProject {
 }
 
 export interface DepsDevAdvisory {
-  advisoryKey: { id: string };
+  advisoryKey: {
+    id: string;
+  };
   url: string;
   title: string;
   aliases: string[];
@@ -118,8 +137,11 @@ export interface DepsDevAdvisory {
 
 async function get<T>(path: string): Promise<T> {
   const url = `${BASE_URL}${path}`;
+
   const res = await fetch(url, {
-    headers: { "User-Agent": `hound-mcp/${__APP_VERSION__}` },
+    headers: {
+      "User-Agent": `hound-mcp/${__APP_VERSION__}`,
+    },
   });
 
   if (!res.ok) {
@@ -150,9 +172,10 @@ export async function getVersion(
   name: string,
   version: string,
 ): Promise<DepsDevVersion> {
-  const sys = ECOSYSTEM_MAP[ecosystem];
+  const system = getDepsDevSystem(ecosystem);
+
   return get<DepsDevVersion>(
-    `/systems/${sys}/packages/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`,
+    `/systems/${system}/packages/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`,
   );
 }
 
@@ -160,9 +183,15 @@ export async function getVersion(
  * Get all versions of a package.
  * Useful for finding available upgrade targets.
  */
-export async function getPackage(ecosystem: Ecosystem, name: string): Promise<DepsDevPackage> {
-  const sys = ECOSYSTEM_MAP[ecosystem];
-  return get<DepsDevPackage>(`/systems/${sys}/packages/${encodeURIComponent(name)}`);
+export async function getPackage(
+  ecosystem: Ecosystem,
+  name: string,
+): Promise<DepsDevPackage> {
+  const system = getDepsDevSystem(ecosystem);
+
+  return get<DepsDevPackage>(
+    `/systems/${system}/packages/${encodeURIComponent(name)}`,
+  );
 }
 
 /**
@@ -175,9 +204,10 @@ export async function getDependencies(
   name: string,
   version: string,
 ): Promise<DepsDevDependencies> {
-  const sys = ECOSYSTEM_MAP[ecosystem];
+  const system = getDepsDevSystem(ecosystem);
+
   return get<DepsDevDependencies>(
-    `/systems/${sys}/packages/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}:dependencies`,
+    `/systems/${system}/packages/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}:dependencies`,
   );
 }
 
@@ -187,14 +217,18 @@ export async function getDependencies(
  */
 export async function getProject(projectId: string): Promise<DepsDevProject> {
   const encoded = projectId.replaceAll("/", "%2F");
+
   return get<DepsDevProject>(`/projects/${encoded}`);
 }
 
 /**
- * Get full advisory details by advisory ID (e.g. "GHSA-rv95-896h-c2vc").
+ * Get full advisory details by advisory ID.
+ * Example: "GHSA-rv95-896h-c2vc"
  */
 export async function getAdvisory(advisoryId: string): Promise<DepsDevAdvisory> {
-  return get<DepsDevAdvisory>(`/advisories/${encodeURIComponent(advisoryId)}`);
+  return get<DepsDevAdvisory>(
+    `/advisories/${encodeURIComponent(advisoryId)}`,
+  );
 }
 
 /**
@@ -203,8 +237,12 @@ export async function getAdvisory(advisoryId: string): Promise<DepsDevAdvisory> 
  */
 export function extractProjectId(version: DepsDevVersion): string | null {
   const related = version.relatedProjects ?? [];
+
   const sourceRepo = related.find(
-    (r) => r.relationType === "SOURCE_REPO" || r.relationType === "ISSUE_TRACKER",
+    (relation) =>
+      relation.relationType === "SOURCE_REPO" ||
+      relation.relationType === "ISSUE_TRACKER",
   );
+
   return sourceRepo?.projectKey.id ?? null;
 }

--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -20,6 +20,7 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   cargo: "crates.io",
   nuget: "NuGet",
   rubygems: "RubyGems",
+  pub: "Pub",
 };
 
 export interface OsvSeverityEntry {

--- a/src/constants/ecosystems.ts
+++ b/src/constants/ecosystems.ts
@@ -6,4 +6,5 @@ export const ECOSYSTEM_VALUES = [
   "cargo",
   "nuget",
   "rubygems",
+  "pub",
 ] as const;

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems";
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub"; 
 }
 
 /**
@@ -18,6 +18,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "Cargo.lock") return parseCargoLock(content);
   if (base === "go.sum") return parseGoSum(content);
   if (base === "Gemfile.lock") return parseGemfileLock(content);
+  if (base === "pubspec.lock") return parsePubspecLock(content);
 
   return null;
 }
@@ -258,6 +259,46 @@ function parseGemfileLock(content: string): ParsedDep[] {
           version = platformMatch[1];
         }
         deps.push({ name: match[1], version, ecosystem: "rubygems" });
+      }
+    }
+  }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// pubspec.lock (Dart/Flutter)
+// ---------------------------------------------------------------------------
+function parsePubspecLock(content: string): ParsedDep[] {
+  const deps: ParsedDep[] = [];
+  const lines = content.split("\n");
+  let inPackages = false;
+  let currentName: string | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith("packages:")) {
+      inPackages = true;
+      continue;
+    }
+
+    if (line.startsWith("sdks:")) {
+      inPackages = false;
+      continue;
+    }
+
+    if (!inPackages) continue;
+
+    const nameMatch = /^ {2}(\S+):/.exec(line);
+    if (nameMatch?.[1]) {
+      currentName = nameMatch[1];
+      continue;
+    }
+
+    if (currentName) {
+      const versionMatch = /^ {4}version:\s+"?([^\s"]+)"?/.exec(line);
+      if (versionMatch?.[1]) {
+        deps.push({ name: currentName, version: versionMatch[1], ecosystem: "pub" });
+        currentName = null;
       }
     }
   }

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -28,6 +28,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
 // ---------------------------------------------------------------------------
 function parsePackageLock(content: string): ParsedDep[] {
   let json: Record<string, unknown>;
+
   try {
     json = JSON.parse(content) as Record<string, unknown>;
   } catch {
@@ -37,15 +38,26 @@ function parsePackageLock(content: string): ParsedDep[] {
   const deps: ParsedDep[] = [];
 
   // v2/v3 format: "packages" object with keys like "node_modules/express"
-  const packages = json.packages as Record<string, { version?: string; dev?: boolean }> | undefined;
+  const packages = json.packages as
+    | Record<string, { version?: string; dev?: boolean }>
+    | undefined;
+
   if (packages) {
     for (const [key, val] of Object.entries(packages)) {
-      if (!key || key === "") continue; // skip root entry
+      if (!key || key === "") continue;
       if (!val.version) continue;
-      // Extract package name from path like "node_modules/foo" or "node_modules/@scope/foo"
+
       const name = key.replace(/^.*node_modules\//, "");
-      if (name) deps.push({ name, version: val.version, ecosystem: "npm" });
+
+      if (name) {
+        deps.push({
+          name,
+          version: val.version,
+          ecosystem: "npm",
+        });
+      }
     }
+
     return deps;
   }
 
@@ -53,6 +65,7 @@ function parsePackageLock(content: string): ParsedDep[] {
   const dependencies = json.dependencies as
     | Record<string, { version?: string; requires?: unknown; dependencies?: unknown }>
     | undefined;
+
   if (dependencies) {
     collectNpmV1(dependencies, deps);
   }
@@ -65,7 +78,14 @@ function collectNpmV1(
   out: ParsedDep[],
 ): void {
   for (const [name, val] of Object.entries(deps)) {
-    if (val.version) out.push({ name, version: val.version, ecosystem: "npm" });
+    if (val.version) {
+      out.push({
+        name,
+        version: val.version,
+        ecosystem: "npm",
+      });
+    }
+
     if (val.dependencies) {
       collectNpmV1(
         val.dependencies as Record<string, { version?: string; dependencies?: unknown }>,
@@ -84,16 +104,14 @@ function parseYarnLock(content: string): ParsedDep[] {
   let currentName: string | null = null;
 
   for (const line of lines) {
-    // Entry header: "package-name@range, package-name@range2:"
     if (
       !line.startsWith(" ") &&
       !line.startsWith("#") &&
       line.includes("@") &&
       line.endsWith(":")
     ) {
-      // Extract package name from first specifier before the @version part
       const first = line.split(",")[0]?.trim().replace(/:$/, "") ?? "";
-      // Handle scoped packages: @scope/name@range
+
       if (first.startsWith("@")) {
         const atIdx = first.indexOf("@", 1);
         currentName = atIdx > 0 ? first.slice(0, atIdx) : null;
@@ -103,8 +121,14 @@ function parseYarnLock(content: string): ParsedDep[] {
       }
     } else if (currentName) {
       const match = /^\s+version\s+"(.+)"/.exec(line);
+
       if (match?.[1]) {
-        deps.push({ name: currentName, version: match[1], ecosystem: "npm" });
+        deps.push({
+          name: currentName,
+          version: match[1],
+          ecosystem: "npm",
+        });
+
         currentName = null;
       }
     }
@@ -120,20 +144,27 @@ function parsePnpmLock(content: string): ParsedDep[] {
   const deps: ParsedDep[] = [];
   const lines = content.split("\n");
 
-  // v9 format: packages section has lines like:
-  //   express@4.18.2:
-  // v6 format: /express/4.18.2:
   for (const line of lines) {
-    // v9: "  name@version:" at top level under "packages:"
     const v9Match = /^ {2}((?:@[^@/]+\/)?[^@/][^@]*)@([^:(@]+):/.exec(line);
+
     if (v9Match?.[1] && v9Match[2]) {
-      deps.push({ name: v9Match[1], version: v9Match[2], ecosystem: "npm" });
+      deps.push({
+        name: v9Match[1],
+        version: v9Match[2],
+        ecosystem: "npm",
+      });
+
       continue;
     }
-    // v6: "  /name/version:" or "  /@scope/name/version:"
+
     const v6Match = /^ {2}\/((?:@[^/]+\/)?[^/]+)\/([^/:(@]+):/.exec(line);
+
     if (v6Match?.[1] && v6Match[2]) {
-      deps.push({ name: v6Match[1], version: v6Match[2], ecosystem: "npm" });
+      deps.push({
+        name: v6Match[1],
+        version: v6Match[2],
+        ecosystem: "npm",
+      });
     }
   }
 
@@ -148,12 +179,19 @@ function parseRequirements(content: string): ParsedDep[] {
 
   for (const raw of content.split("\n")) {
     const line = raw.split("#")[0]?.trim() ?? "";
-    if (!line || line.startsWith("-")) continue;
 
-    // name==version or name===version
+    if (!line || line.startsWith("-")) {
+      continue;
+    }
+
     const eqMatch = /^([A-Za-z0-9_.-]+)==?=?([^\s;]+)/.exec(line);
+
     if (eqMatch?.[1] && eqMatch[2]) {
-      deps.push({ name: eqMatch[1].toLowerCase(), version: eqMatch[2], ecosystem: "pypi" });
+      deps.push({
+        name: eqMatch[1].toLowerCase(),
+        version: eqMatch[2],
+        ecosystem: "pypi",
+      });
     }
   }
 
@@ -171,19 +209,41 @@ function parseCargoLock(content: string): ParsedDep[] {
 
   for (const raw of content.split("\n")) {
     const line = raw.trim();
+
     if (line === "[[package]]") {
-      if (name && version) deps.push({ name, version, ecosystem: "cargo" });
+      if (name && version) {
+        deps.push({
+          name,
+          version,
+          ecosystem: "cargo",
+        });
+      }
+
       name = null;
       version = null;
       inPackage = true;
     } else if (inPackage) {
       const nameMatch = /^name\s*=\s*"([^"]+)"/.exec(line);
-      if (nameMatch?.[1]) name = nameMatch[1];
+
+      if (nameMatch?.[1]) {
+        name = nameMatch[1];
+      }
+
       const verMatch = /^version\s*=\s*"([^"]+)"/.exec(line);
-      if (verMatch?.[1]) version = verMatch[1];
+
+      if (verMatch?.[1]) {
+        version = verMatch[1];
+      }
     }
   }
-  if (name && version) deps.push({ name, version, ecosystem: "cargo" });
+
+  if (name && version) {
+    deps.push({
+      name,
+      version,
+      ecosystem: "cargo",
+    });
+  }
 
   return deps;
 }
@@ -196,14 +256,19 @@ function parseGoSum(content: string): ParsedDep[] {
   const deps: ParsedDep[] = [];
 
   for (const line of content.split("\n")) {
-    // format: module/path v1.2.3 h1:hash=
-    // or:     module/path v1.2.3/go.mod h1:hash=
     const match = /^(\S+)\s+v([^\s/]+)/.exec(line);
+
     if (match?.[1] && match[2]) {
       const key = `${match[1]}@${match[2]}`;
+
       if (!seen.has(key)) {
         seen.add(key);
-        deps.push({ name: match[1], version: match[2], ecosystem: "go" });
+
+        deps.push({
+          name: match[1],
+          version: match[2],
+          ecosystem: "go",
+        });
       }
     }
   }
@@ -221,44 +286,43 @@ function parseGemfileLock(content: string): ParsedDep[] {
   let inSpecs = false;
 
   for (const line of lines) {
-    // Track if we're in the GEM section (not GIT, PATH, etc.)
     if (line.startsWith("GEM")) {
       inGemSection = true;
       inSpecs = false;
       continue;
     }
 
-    // Exit GEM section when we hit another top-level section
     if (line.length > 0 && !line.startsWith(" ")) {
       inGemSection = false;
       inSpecs = false;
       continue;
     }
 
-    // Start of specs section (only parse if in GEM section)
     if (inGemSection && line.trim() === "specs:") {
       inSpecs = true;
       continue;
     }
 
     if (inSpecs) {
-      // Match gem spec entries: "    actioncable (7.0.3.1)"
-      // Spec entries are indented with 4 spaces
-      // Dependency lines like "      actionpack (= 7.0.3.1)" are indented with 6+ spaces and ignored
       const match = /^ {4}([A-Za-z0-9_.-]+)\s+\(([^\s)]+)\)/.exec(line);
+
       if (match?.[1] && match[2]) {
         let version = match[2];
-        // Strip platform suffix from versions like "1.14.2-x86_64-darwin" -> "1.14.2"
-        // Platform suffixes follow the pattern: -<platform>-<os> or -<platform>, at the end of the string
-        // Keep legitimate prerelease identifiers like "7.1.0-beta.1-x86_64-darwin" -> "7.1.0-beta.1"
+
         const platformMatch =
           /^(.+)-(x86_64|arm64|aarch64|universal|java|mingw32|mswin32|x64_mingw32)(?:-[a-z0-9_]+)?$/i.exec(
             version,
           );
+
         if (platformMatch?.[1]) {
           version = platformMatch[1];
         }
-        deps.push({ name: match[1], version, ecosystem: "rubygems" });
+
+        deps.push({
+          name: match[1],
+          version,
+          ecosystem: "rubygems",
+        });
       }
     }
   }
@@ -272,8 +336,10 @@ function parseGemfileLock(content: string): ParsedDep[] {
 function parsePubspecLock(content: string): ParsedDep[] {
   const deps: ParsedDep[] = [];
   const lines = content.split("\n");
+
   let inPackages = false;
   let currentName: string | null = null;
+  let currentSource: string | null = null;
 
   for (const line of lines) {
     if (line.startsWith("packages:")) {
@@ -283,23 +349,47 @@ function parsePubspecLock(content: string): ParsedDep[] {
 
     if (line.startsWith("sdks:")) {
       inPackages = false;
+      currentName = null;
+      currentSource = null;
       continue;
     }
 
-    if (!inPackages) continue;
+    if (!inPackages) {
+      continue;
+    }
 
     const nameMatch = /^ {2}(\S+):/.exec(line);
+
     if (nameMatch?.[1]) {
       currentName = nameMatch[1];
+      currentSource = null;
       continue;
     }
 
-    if (currentName) {
-      const versionMatch = /^ {4}version:\s+"?([^\s"]+)"?/.exec(line);
-      if (versionMatch?.[1]) {
-        deps.push({ name: currentName, version: versionMatch[1], ecosystem: "pub" });
-        currentName = null;
+    if (!currentName) {
+      continue;
+    }
+
+    const sourceMatch = /^ {4}source:\s+"?([^\s"]+)"?/.exec(line);
+
+    if (sourceMatch?.[1]) {
+      currentSource = sourceMatch[1];
+      continue;
+    }
+
+    const versionMatch = /^ {4}version:\s+"?([^\s"]+)"?/.exec(line);
+
+    if (versionMatch?.[1]) {
+      if (currentSource !== "sdk") {
+        deps.push({
+          name: currentName,
+          version: versionMatch[1],
+          ecosystem: "pub",
+        });
       }
+
+      currentName = null;
+      currentSource = null;
     }
   }
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub"; 
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub";
 }
 
 /**

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -1,11 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod/v4";
-import { parseLockfile } from "../parsers/index.js";
 import { extractSeverity, queryVulnsBatch } from "../api/osv.js";
+import { parseLockfile } from "../parsers/index.js";
 import type { Ecosystem } from "../types/index.js";
 import { formatUnsupportedLockfileMessage } from "../utils/lockfileFormat.js";
 
-const MAX_BATCH = 100; // cap to avoid huge requests
+const MAX_BATCH = 100; // Cap to avoid huge requests
 
 const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MODERATE", "LOW", "UNKNOWN"] as const;
 
@@ -40,11 +40,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-<<<<<<< HEAD
               text: formatUnsupportedLockfileMessage(lockfile_name),
-=======
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, or pubspec.lock`,
->>>>>>> de59d46 (Complete Pub ecosystem integration)
             },
           ],
         };
@@ -61,11 +57,16 @@ export function register(server: McpServer) {
         };
       }
 
-      // Deduplicate by name@version
+      // Deduplicate dependencies by name and version.
       const seen = new Set<string>();
-      const unique = deps.filter((d) => {
-        const key = `${d.name}@${d.version}`;
-        if (seen.has(key)) return false;
+
+      const unique = deps.filter((dependency) => {
+        const key = `${dependency.name}@${dependency.version}`;
+
+        if (seen.has(key)) {
+          return false;
+        }
+
         seen.add(key);
         return true;
       });
@@ -73,16 +74,15 @@ export function register(server: McpServer) {
       const toCheck = unique.slice(0, MAX_BATCH);
       const truncated = unique.length > MAX_BATCH;
 
-      // Batch query OSV
-      const vulnResults = await queryVulnsBatch(
-        toCheck.map((d) => ({
-          ecosystem: d.ecosystem as Ecosystem,
-          name: d.name,
-          version: d.version,
+      // Query OSV for all selected dependencies in one batch.
+      const vulnerabilityResults = await queryVulnsBatch(
+        toCheck.map((dependency) => ({
+          ecosystem: dependency.ecosystem as Ecosystem,
+          name: dependency.name,
+          version: dependency.version,
         })),
       );
 
-      // Build vulnerability findings
       interface Finding {
         name: string;
         version: string;
@@ -92,85 +92,98 @@ export function register(server: McpServer) {
       }
 
       const findings: Finding[] = [];
-      const vulnCounts: Partial<Record<string, number>> = {};
+      const vulnerabilityCounts: Partial<Record<string, number>> = {};
 
-      for (let i = 0; i < toCheck.length; i++) {
-        const dep = toCheck[i];
-        const vulns = vulnResults[i] ?? [];
-        if (!dep) continue;
+      for (let index = 0; index < toCheck.length; index++) {
+        const dependency = toCheck[index];
 
-        for (const v of vulns) {
-          const sev = extractSeverity(v);
-          vulnCounts[sev] = (vulnCounts[sev] ?? 0) + 1;
+        if (!dependency) {
+          continue;
+        }
+
+        const vulnerabilities = vulnerabilityResults[index] ?? [];
+
+        for (const vulnerability of vulnerabilities) {
+          const severity = extractSeverity(vulnerability);
+
+          vulnerabilityCounts[severity] = (vulnerabilityCounts[severity] ?? 0) + 1;
 
           findings.push({
-            name: dep.name,
-            version: dep.version,
-            severity: sev,
-            id: v.id,
-            summary: v.summary,
+            name: dependency.name,
+            version: dependency.version,
+            severity,
+            id: vulnerability.id,
+            summary: vulnerability.summary,
           });
         }
       }
 
-      const totalVulns = findings.length;
-      const affectedPkgs = new Set(findings.map((f) => `${f.name}@${f.version}`)).size;
+      const totalVulnerabilities = findings.length;
 
-      // --- Report ---
+      const affectedPackages = new Set(
+        findings.map((finding) => `${finding.name}@${finding.version}`),
+      ).size;
+
       const lines: string[] = [
         "📊 Hound Audit Report",
         "═".repeat(50),
         `Lockfile: ${lockfile_name}`,
-        `Scanned:  ${toCheck.length} dependencies${truncated ? ` (capped at ${MAX_BATCH} of ${unique.length})` : ""}`,
+        `Scanned:  ${toCheck.length} dependencies${
+          truncated ? ` (capped at ${MAX_BATCH} of ${unique.length})` : ""
+        }`,
         "",
       ];
 
-      // Summary counts
-      if (totalVulns === 0) {
+      if (totalVulnerabilities === 0) {
         lines.push("✅ No known vulnerabilities found!");
       } else {
         lines.push(
-          `Found ${totalVulns} vulnerabilit${totalVulns === 1 ? "y" : "ies"} across ${affectedPkgs} package${affectedPkgs === 1 ? "" : "s"}:`,
+          `Found ${totalVulnerabilities} vulnerabilit${
+            totalVulnerabilities === 1 ? "y" : "ies"
+          } across ${affectedPackages} package${affectedPackages === 1 ? "" : "s"}:`,
         );
 
-        for (const sev of SEVERITY_ORDER) {
-          const count = vulnCounts[sev] ?? 0;
+        for (const severity of SEVERITY_ORDER) {
+          const count = vulnerabilityCounts[severity] ?? 0;
 
           if (count > 0) {
-            const icon = SEVERITY_ICON[sev] ?? "⚪";
-            lines.push(`  ${icon} ${count} ${sev.toLowerCase()}`);
+            const icon = SEVERITY_ICON[severity] ?? "⚪";
+            lines.push(`  ${icon} ${count} ${severity.toLowerCase()}`);
           }
         }
       }
 
       lines.push("");
 
-      // Detailed findings grouped by severity
       if (findings.length > 0) {
         lines.push("─".repeat(50));
         lines.push("Vulnerable Packages");
         lines.push("─".repeat(50));
 
-        for (const sev of SEVERITY_ORDER) {
-          const group = findings.filter((f) => f.severity === sev);
-          if (group.length === 0) continue;
+        for (const severity of SEVERITY_ORDER) {
+          const group = findings.filter((finding) => finding.severity === severity);
 
-          const icon = SEVERITY_ICON[sev] ?? "⚪";
-          lines.push(`\n${icon} ${sev} (${group.length})`);
-
-          // Group by package
-          const byPkg: Record<string, Finding[]> = {};
-
-          for (const f of group) {
-            const key = `${f.name}@${f.version}`;
-            (byPkg[key] ??= []).push(f);
+          if (group.length === 0) {
+            continue;
           }
 
-          for (const [pkg, pkgFindings] of Object.entries(byPkg)) {
-            lines.push(`  ${pkg}`);
+          const icon = SEVERITY_ICON[severity] ?? "⚪";
+          lines.push(`\n${icon} ${severity} (${group.length})`);
 
-            for (const f of pkgFindings) {
-              lines.push(`    ${f.id}: ${f.summary}`);
+          const findingsByPackage: Record<string, Finding[]> = {};
+
+          for (const finding of group) {
+            const key = `${finding.name}@${finding.version}`;
+            (findingsByPackage[key] ??= []).push(finding);
+          }
+
+          for (const [packageName, packageFindings] of Object.entries(
+            findingsByPackage,
+          )) {
+            lines.push(`  ${packageName}`);
+
+            for (const finding of packageFindings) {
+              lines.push(`    ${finding.id}: ${finding.summary}`);
             }
           }
         }
@@ -192,7 +205,12 @@ export function register(server: McpServer) {
       lines.push("Source: OSV.dev");
 
       return {
-        content: [{ type: "text", text: lines.join("\n") }],
+        content: [
+          {
+            type: "text",
+            text: lines.join("\n"),
+          },
+        ],
       };
     },
   );

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,13 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, or pubspec.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, or pubspec.lock",
           ),
       },
     },
@@ -40,7 +40,11 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
+<<<<<<< HEAD
               text: formatUnsupportedLockfileMessage(lockfile_name),
+=======
+              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, or pubspec.lock`,
+>>>>>>> de59d46 (Complete Pub ecosystem integration)
             },
           ],
         };
@@ -94,9 +98,11 @@ export function register(server: McpServer) {
         const dep = toCheck[i];
         const vulns = vulnResults[i] ?? [];
         if (!dep) continue;
+
         for (const v of vulns) {
           const sev = extractSeverity(v);
           vulnCounts[sev] = (vulnCounts[sev] ?? 0) + 1;
+
           findings.push({
             name: dep.name,
             version: dep.version,
@@ -126,8 +132,10 @@ export function register(server: McpServer) {
         lines.push(
           `Found ${totalVulns} vulnerabilit${totalVulns === 1 ? "y" : "ies"} across ${affectedPkgs} package${affectedPkgs === 1 ? "" : "s"}:`,
         );
+
         for (const sev of SEVERITY_ORDER) {
           const count = vulnCounts[sev] ?? 0;
+
           if (count > 0) {
             const icon = SEVERITY_ICON[sev] ?? "⚪";
             lines.push(`  ${icon} ${count} ${sev.toLowerCase()}`);
@@ -152,6 +160,7 @@ export function register(server: McpServer) {
 
           // Group by package
           const byPkg: Record<string, Finding[]> = {};
+
           for (const f of group) {
             const key = `${f.name}@${f.version}`;
             (byPkg[key] ??= []).push(f);
@@ -159,6 +168,7 @@ export function register(server: McpServer) {
 
           for (const [pkg, pkgFindings] of Object.entries(byPkg)) {
             lines.push(`  ${pkg}`);
+
             for (const f of pkgFindings) {
               lines.push(`    ${f.id}: ${f.summary}`);
             }

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -52,6 +52,7 @@ function classifyLicense(
   license: string,
 ): "permissive" | "weak-copyleft" | "copyleft" | "network-copyleft" | "unknown" {
   if (NETWORK_COPYLEFT.has(license)) return "network-copyleft";
+
   if (COPYLEFT_LICENSES.has(license)) {
     if (
       license.startsWith("LGPL") ||
@@ -62,9 +63,12 @@ function classifyLicense(
     ) {
       return "weak-copyleft";
     }
+
     return "copyleft";
   }
+
   if (POLICY_ALLOWLISTS.permissive.has(license)) return "permissive";
+
   return "unknown";
 }
 
@@ -105,6 +109,17 @@ export function register(server: McpServer) {
         };
       }
 
+      if (deps.some((dep) => dep.ecosystem === "pub")) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "License checking for pubspec.lock is not currently supported because deps.dev does not support the Pub ecosystem.",
+            },
+          ],
+        };
+      }
+
       if (deps.length === 0) {
         return {
           content: [{ type: "text", text: `No dependencies found in ${lockfile_name}.` }],
@@ -115,7 +130,9 @@ export function register(server: McpServer) {
       const seen = new Set<string>();
       const unique = deps.filter((d) => {
         const key = `${d.name}@${d.version}`;
+
         if (seen.has(key)) return false;
+
         seen.add(key);
         return true;
       });
@@ -143,13 +160,15 @@ export function register(server: McpServer) {
 
       for (let i = 0; i < toFetch.length; i++) {
         const dep = toFetch[i];
+
         if (!dep) continue;
+
         const result = licenseResults[i];
         const licenses = result?.status === "fulfilled" ? (result.value.licenses ?? []) : [];
 
         // Count each license
-        for (const l of licenses) {
-          licenseCount[l] = (licenseCount[l] ?? 0) + 1;
+        for (const license of licenses) {
+          licenseCount[license] = (licenseCount[license] ?? 0) + 1;
         }
 
         // Determine if flagged
@@ -160,7 +179,8 @@ export function register(server: McpServer) {
           flagged = policy !== "none";
           reason = "License unknown";
         } else if (allowlist) {
-          const violating = licenses.filter((l) => !allowlist.has(l));
+          const violating = licenses.filter((license) => !allowlist.has(license));
+
           if (violating.length > 0) {
             flagged = true;
             reason = `License not allowed under ${policy} policy: ${violating.join(", ")}`;
@@ -170,7 +190,7 @@ export function register(server: McpServer) {
         const classification =
           licenses.length === 0 ? "unknown" : licenses.map(classifyLicense).join(", ");
 
-        if (flagged || licenses.some((l) => classifyLicense(l) !== "permissive")) {
+        if (flagged || licenses.some((license) => classifyLicense(license) !== "permissive")) {
           results.push({
             name: dep.name,
             version: dep.version,
@@ -182,8 +202,8 @@ export function register(server: McpServer) {
         }
       }
 
-      const flagged = results.filter((r) => r.flagged);
-      const infoOnly = results.filter((r) => !r.flagged);
+      const flagged = results.filter((result) => result.flagged);
+      const infoOnly = results.filter((result) => !result.flagged);
 
       const lines: string[] = [
         "🔏 Hound License Check",
@@ -195,7 +215,8 @@ export function register(server: McpServer) {
       ];
 
       if (flagged.length === 0) {
-        lines.push(`✅ No license violations found`);
+        lines.push("✅ No license violations found");
+
         if (policy !== "none") {
           lines.push(`   All scanned packages comply with the ${policy} policy.`);
         }
@@ -204,11 +225,13 @@ export function register(server: McpServer) {
           `⚠️  ${flagged.length} license violation${flagged.length === 1 ? "" : "s"} found`,
         );
         lines.push("─".repeat(50));
-        for (const r of flagged) {
-          const lic = r.licenses.length > 0 ? r.licenses.join(", ") : "unknown";
-          lines.push(`  ${r.name}@${r.version}`);
-          lines.push(`    License: ${lic}`);
-          lines.push(`    ${r.reason}`);
+
+        for (const result of flagged) {
+          const license = result.licenses.length > 0 ? result.licenses.join(", ") : "unknown";
+
+          lines.push(`  ${result.name}@${result.version}`);
+          lines.push(`    License: ${license}`);
+          lines.push(`    ${result.reason}`);
           lines.push("");
         }
       }
@@ -216,10 +239,12 @@ export function register(server: McpServer) {
       if (infoOnly.length > 0) {
         lines.push("─".repeat(50));
         lines.push("Non-permissive licenses (not violations):");
-        for (const r of infoOnly) {
-          const lic = r.licenses.join(", ");
-          lines.push(`  ${r.name}@${r.version}  ${lic}`);
+
+        for (const result of infoOnly) {
+          const license = result.licenses.join(", ");
+          lines.push(`  ${result.name}@${result.version}  ${license}`);
         }
+
         lines.push("");
       }
 
@@ -231,9 +256,11 @@ export function register(server: McpServer) {
       if (topLicenses.length > 0) {
         lines.push("─".repeat(50));
         lines.push("License distribution:");
-        for (const [lic, count] of topLicenses) {
-          lines.push(`  ${String(count).padStart(4)}×  ${lic}`);
+
+        for (const [license, count] of topLicenses) {
+          lines.push(`  ${String(count).padStart(4)}×  ${license}`);
         }
+
         lines.push("");
       }
 

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -82,11 +82,15 @@ export function register(server: McpServer) {
         "Scan a lockfile for license compliance. Resolves licenses for every dependency and flags packages that violate the chosen policy (permissive, copyleft, or none).",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
+
+        // pubspec.lock is intentionally omitted here because deps.dev does not
+        // support the Pub ecosystem. The handler below returns an explicit message.
         lockfile_name: z
           .string()
           .describe(
             "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
           ),
+
         policy: z
           .enum(["permissive", "copyleft", "none"])
           .default("permissive")
@@ -109,6 +113,7 @@ export function register(server: McpServer) {
         };
       }
 
+      // Pub dependencies can be parsed, but deps.dev cannot resolve their licenses.
       if (deps.some((dep) => dep.ecosystem === "pub")) {
         return {
           content: [
@@ -128,8 +133,9 @@ export function register(server: McpServer) {
 
       // Deduplicate
       const seen = new Set<string>();
-      const unique = deps.filter((d) => {
-        const key = `${d.name}@${d.version}`;
+
+      const unique = deps.filter((dep) => {
+        const key = `${dep.name}@${dep.version}`;
 
         if (seen.has(key)) return false;
 
@@ -140,9 +146,9 @@ export function register(server: McpServer) {
       const toFetch = unique.slice(0, MAX_FETCH);
       const truncated = unique.length > MAX_FETCH;
 
-      // Fetch licenses in parallel (ignore failures)
+      // Fetch licenses in parallel and ignore individual request failures.
       const licenseResults = await Promise.allSettled(
-        toFetch.map((d) => getVersion(d.ecosystem as Ecosystem, d.name, d.version)),
+        toFetch.map((dep) => getVersion(dep.ecosystem as Ecosystem, dep.name, dep.version)),
       );
 
       interface LicenseResult {
@@ -158,20 +164,21 @@ export function register(server: McpServer) {
       const results: LicenseResult[] = [];
       const licenseCount: Record<string, number> = {};
 
-      for (let i = 0; i < toFetch.length; i++) {
-        const dep = toFetch[i];
+      for (let index = 0; index < toFetch.length; index++) {
+        const dep = toFetch[index];
 
         if (!dep) continue;
 
-        const result = licenseResults[i];
-        const licenses = result?.status === "fulfilled" ? (result.value.licenses ?? []) : [];
+        const result = licenseResults[index];
+        const licenses =
+          result?.status === "fulfilled" ? (result.value.licenses ?? []) : [];
 
-        // Count each license
+        // Count each license.
         for (const license of licenses) {
           licenseCount[license] = (licenseCount[license] ?? 0) + 1;
         }
 
-        // Determine if flagged
+        // Determine whether the package violates the selected policy.
         let flagged = false;
         let reason = "";
 
@@ -188,9 +195,14 @@ export function register(server: McpServer) {
         }
 
         const classification =
-          licenses.length === 0 ? "unknown" : licenses.map(classifyLicense).join(", ");
+          licenses.length === 0
+            ? "unknown"
+            : licenses.map(classifyLicense).join(", ");
 
-        if (flagged || licenses.some((license) => classifyLicense(license) !== "permissive")) {
+        if (
+          flagged ||
+          licenses.some((license) => classifyLicense(license) !== "permissive")
+        ) {
           results.push({
             name: dep.name,
             version: dep.version,
@@ -210,7 +222,9 @@ export function register(server: McpServer) {
         "═".repeat(50),
         `Lockfile:  ${lockfile_name}`,
         `Policy:    ${policy}`,
-        `Scanned:   ${toFetch.length} packages${truncated ? ` (first ${MAX_FETCH} of ${unique.length})` : ""}`,
+        `Scanned:   ${toFetch.length} packages${
+          truncated ? ` (first ${MAX_FETCH} of ${unique.length})` : ""
+        }`,
         "",
       ];
 
@@ -222,12 +236,17 @@ export function register(server: McpServer) {
         }
       } else {
         lines.push(
-          `⚠️  ${flagged.length} license violation${flagged.length === 1 ? "" : "s"} found`,
+          `⚠️  ${flagged.length} license violation${
+            flagged.length === 1 ? "" : "s"
+          } found`,
         );
         lines.push("─".repeat(50));
 
         for (const result of flagged) {
-          const license = result.licenses.length > 0 ? result.licenses.join(", ") : "unknown";
+          const license =
+            result.licenses.length > 0
+              ? result.licenses.join(", ")
+              : "unknown";
 
           lines.push(`  ${result.name}@${result.version}`);
           lines.push(`    License: ${license}`);
@@ -267,7 +286,12 @@ export function register(server: McpServer) {
       lines.push("Source: deps.dev");
 
       return {
-        content: [{ type: "text", text: lines.join("\n") }],
+        content: [
+          {
+            type: "text",
+            text: lines.join("\n"),
+          },
+        ],
       };
     },
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@
 // Ecosystems
 // ---------------------------------------------------------------------------
 
-export type Ecosystem = "npm" | "pypi" | "go" | "maven" | "cargo" | "nuget" | "rubygems";
+export type Ecosystem = "npm" | "pypi" | "go" | "maven" | "cargo" | "nuget" | "rubygems" | "pub";
 
 // ---------------------------------------------------------------------------
 // Parsed dependency (output of lockfile parsers)

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -400,7 +400,7 @@ GEM
     expect(deps).toContainEqual({ name: "net-ssh", version: "7.0.1", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "i18n", version: "1.12.0", ecosystem: "rubygems" });
   });
-  });
+});
 
 // ---------------------------------------------------------------------------
 // pubspec.lock

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -400,4 +400,40 @@ GEM
     expect(deps).toContainEqual({ name: "net-ssh", version: "7.0.1", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "i18n", version: "1.12.0", ecosystem: "rubygems" });
   });
+  });
+
+// ---------------------------------------------------------------------------
+// pubspec.lock
+// ---------------------------------------------------------------------------
+
+describe("pubspec.lock", () => {
+  it("parses packages and ignores sdks section", () => {
+    const content = `packages:
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "abc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  path:
+    dependency: transitive
+    description:
+      name: path
+      sha256: "def"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.3"
+sdks:
+  dart: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
+`;
+
+    const deps = parseLockfile("pubspec.lock", content);
+
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "http", version: "1.1.0", ecosystem: "pub" });
+    expect(deps).toContainEqual({ name: "path", version: "1.8.3", ecosystem: "pub" });
+  });
 });

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -406,6 +406,10 @@ GEM
 // pubspec.lock
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// pubspec.lock
+// ---------------------------------------------------------------------------
+
 describe("pubspec.lock", () => {
   it("parses packages and ignores sdks section", () => {
     const content = `packages:
@@ -433,7 +437,50 @@ sdks:
     const deps = parseLockfile("pubspec.lock", content);
 
     expect(deps).toHaveLength(2);
-    expect(deps).toContainEqual({ name: "http", version: "1.1.0", ecosystem: "pub" });
-    expect(deps).toContainEqual({ name: "path", version: "1.8.3", ecosystem: "pub" });
+    expect(deps).toContainEqual({
+      name: "http",
+      version: "1.1.0",
+      ecosystem: "pub",
+    });
+    expect(deps).toContainEqual({
+      name: "path",
+      version: "1.8.3",
+      ecosystem: "pub",
+    });
+  });
+
+  it("skips SDK pseudo-packages", () => {
+    const content = `packages:
+  flutter:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.99"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+sdks:
+  dart: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
+`;
+
+    const deps = parseLockfile("pubspec.lock", content);
+
+    expect(deps).toEqual([
+      {
+        name: "http",
+        version: "1.1.0",
+        ecosystem: "pub",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds support for parsing Dart/Flutter `pubspec.lock` files.

## Why?

This enables dependency parsing for Dart/Flutter projects using the pub.dev ecosystem.

## Type of change

- [ ] Bug fix
- [ ] New tool
- [x] New lockfile parser
- [ ] Improvement to existing tool
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `pnpm check` passes
- [x] New functionality has tests
- [ ] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed

## Testing

Verified with:

```bash
pnpm check