### PR TITLE
Add retry with exponential backoff to API clients

### DIFF
--- a/src/api/depsdev.ts
+++ b/src/api/depsdev.ts
@@ -8,7 +8,7 @@
  * Ecosystem names in URLs must be uppercase (NPM, PYPI, GO, MAVEN, CARGO, NUGET, RUBYGEMS).
  * Project keys use %2F encoding for slashes (github.com%2Fowner%2Frepo).
  */
-
+import { fetchWithRetry } from "./retry.js";
 import type { Ecosystem } from "../types/index.js";
 
 const BASE_URL = "https://api.deps.dev/v3";
@@ -137,11 +137,8 @@ export interface DepsDevAdvisory {
 
 async function get<T>(path: string): Promise<T> {
   const url = `${BASE_URL}${path}`;
-
-  const res = await fetch(url, {
-    headers: {
-      "User-Agent": `hound-mcp/${__APP_VERSION__}`,
-    },
+  const res = await fetchWithRetry(url, {
+    headers: { "User-Agent": `hound-mcp/${__APP_VERSION__}` },
   });
 
   if (!res.ok) {
@@ -183,15 +180,10 @@ export async function getVersion(
  * Get all versions of a package.
  * Useful for finding available upgrade targets.
  */
-export async function getPackage(
-  ecosystem: Ecosystem,
-  name: string,
-): Promise<DepsDevPackage> {
+export async function getPackage(ecosystem: Ecosystem, name: string): Promise<DepsDevPackage> {
   const system = getDepsDevSystem(ecosystem);
 
-  return get<DepsDevPackage>(
-    `/systems/${system}/packages/${encodeURIComponent(name)}`,
-  );
+  return get<DepsDevPackage>(`/systems/${system}/packages/${encodeURIComponent(name)}`);
 }
 
 /**
@@ -226,9 +218,7 @@ export async function getProject(projectId: string): Promise<DepsDevProject> {
  * Example: "GHSA-rv95-896h-c2vc"
  */
 export async function getAdvisory(advisoryId: string): Promise<DepsDevAdvisory> {
-  return get<DepsDevAdvisory>(
-    `/advisories/${encodeURIComponent(advisoryId)}`,
-  );
+  return get<DepsDevAdvisory>(`/advisories/${encodeURIComponent(advisoryId)}`);
 }
 
 /**
@@ -240,8 +230,7 @@ export function extractProjectId(version: DepsDevVersion): string | null {
 
   const sourceRepo = related.find(
     (relation) =>
-      relation.relationType === "SOURCE_REPO" ||
-      relation.relationType === "ISSUE_TRACKER",
+      relation.relationType === "SOURCE_REPO" || relation.relationType === "ISSUE_TRACKER",
   );
 
   return sourceRepo?.projectKey.id ?? null;

--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -7,7 +7,7 @@
  *
  * Ecosystem names use OSV convention (npm, PyPI, Go, Maven, crates.io, NuGet, RubyGems).
  */
-
+import { fetchWithRetry } from "./retry.js";
 import type { Ecosystem, Severity } from "../types/index.js";
 
 const BASE_URL = "https://api.osv.dev/v1";
@@ -80,7 +80,7 @@ export interface OsvBatchResponse {
 
 async function post<TResponse>(path: string, body: unknown): Promise<TResponse> {
   const url = `${BASE_URL}${path}`;
-  const res = await fetch(url, {
+  const res = await fetchWithRetry(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -155,7 +155,7 @@ export async function queryVulnsBatch(
  */
 export async function getVuln(vulnId: string): Promise<OsvVuln> {
   const url = `${BASE_URL}/vulns/${encodeURIComponent(vulnId)}`;
-  const res = await fetch(url, {
+  const res = await fetchWithRetry(url, {
     headers: { "User-Agent": `hound-mcp/${__APP_VERSION__}` },
   });
 

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -1,0 +1,65 @@
+interface RetryResponse {
+  status: number;
+  ok: boolean;
+  headers?: {
+    get(name: string): string | null;
+  };
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
+declare const fetch: (url: string, options?: unknown) => Promise<RetryResponse>;
+
+declare function setTimeout(handler: () => void, timeout: number): unknown;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function getRetryDelay(response: RetryResponse, fallbackDelay: number): number {
+  const retryAfter = response.headers?.get("Retry-After");
+
+  if (!retryAfter) {
+    return fallbackDelay;
+  }
+
+  const seconds = Number(retryAfter);
+
+  if (!Number.isNaN(seconds)) {
+    return seconds * 1000;
+  }
+
+  const retryDate = Date.parse(retryAfter);
+
+  if (!Number.isNaN(retryDate)) {
+    return Math.max(0, retryDate - Date.now());
+  }
+
+  return fallbackDelay;
+}
+
+export async function fetchWithRetry(url: string, options?: unknown): Promise<RetryResponse> {
+  const delays = [100, 400];
+
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    const response = await fetch(url, options);
+
+    if (![429, 503].includes(response.status)) {
+      return response;
+    }
+
+    if (attempt === delays.length) {
+      return response;
+    }
+
+    const fallbackDelay = delays[attempt] ?? 400;
+
+    const delay = getRetryDelay(response, fallbackDelay);
+
+    await sleep(delay);
+  }
+
+  throw new Error("Unexpected retry failure");
+}

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -8,14 +8,8 @@ interface RetryResponse {
   json(): Promise<unknown>;
 }
 
-declare const fetch: (url: string, options?: unknown) => Promise<RetryResponse>;
-
-declare function setTimeout(handler: () => void, timeout: number): unknown;
-
 function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 export function getRetryDelay(response: RetryResponse, fallbackDelay: number): number {
@@ -44,7 +38,7 @@ export async function fetchWithRetry(url: string, options?: unknown): Promise<Re
   const delays = [100, 400];
 
   for (let attempt = 0; attempt <= delays.length; attempt++) {
-    const response = await fetch(url, options);
+    const response = await globalThis.fetch(url, options);
 
     if (![429, 503].includes(response.status)) {
       return response;

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -8,30 +8,35 @@ interface RetryResponse {
   json(): Promise<unknown>;
 }
 
+// Cap any single retry wait so a hostile/overloaded server's large Retry-After
+// can't freeze the tool for minutes (it runs as a local agent tool).
+const MAX_RETRY_DELAY_MS = 5000;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
 export function getRetryDelay(response: RetryResponse, fallbackDelay: number): number {
+  const cap = (ms: number) => Math.min(ms, MAX_RETRY_DELAY_MS);
   const retryAfter = response.headers?.get("Retry-After");
 
   if (!retryAfter) {
-    return fallbackDelay;
+    return cap(fallbackDelay);
   }
 
   const seconds = Number(retryAfter);
 
   if (!Number.isNaN(seconds)) {
-    return seconds * 1000;
+    return cap(seconds * 1000);
   }
 
   const retryDate = Date.parse(retryAfter);
 
   if (!Number.isNaN(retryDate)) {
-    return Math.max(0, retryDate - Date.now());
+    return cap(Math.max(0, retryDate - Date.now()));
   }
 
-  return fallbackDelay;
+  return cap(fallbackDelay);
 }
 
 export async function fetchWithRetry(url: string, options?: unknown): Promise<RetryResponse> {
@@ -50,9 +55,7 @@ export async function fetchWithRetry(url: string, options?: unknown): Promise<Re
 
     const fallbackDelay = delays[attempt] ?? 400;
 
-    const delay = Math.min(getRetryDelay(response, fallbackDelay), 5000);
-
-    await sleep(delay);
+    await sleep(getRetryDelay(response, fallbackDelay));
   }
 
   throw new Error("Unexpected retry failure");

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -18,7 +18,7 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function getRetryDelay(response: RetryResponse, fallbackDelay: number): number {
+export function getRetryDelay(response: RetryResponse, fallbackDelay: number): number {
   const retryAfter = response.headers?.get("Retry-After");
 
   if (!retryAfter) {
@@ -56,7 +56,7 @@ export async function fetchWithRetry(url: string, options?: unknown): Promise<Re
 
     const fallbackDelay = delays[attempt] ?? 400;
 
-    const delay = getRetryDelay(response, fallbackDelay);
+    const delay = Math.min(getRetryDelay(response, fallbackDelay), 5000);
 
     await sleep(delay);
   }

--- a/src/api/retry.ts
+++ b/src/api/retry.ts
@@ -38,7 +38,7 @@ export async function fetchWithRetry(url: string, options?: unknown): Promise<Re
   const delays = [100, 400];
 
   for (let attempt = 0; attempt <= delays.length; attempt++) {
-    const response = await globalThis.fetch(url, options);
+    const response = await globalThis.fetch(url, options as RequestInit | undefined);
 
     if (![429, 503].includes(response.status)) {
       return response;

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -25,8 +25,8 @@ describe("fetchWithRetry", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("retries and eventually succeeds", async () => {

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -27,6 +27,12 @@ describe("fetchWithRetry", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+  }, 15000); // 15 second timeout for cleanup
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("retries and eventually succeeds", async () => {

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -24,16 +24,11 @@ describe("fetchWithRetry", () => {
     vi.useFakeTimers();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-  }, 15000); // 15 second timeout for cleanup
-
   afterEach(async () => {
     await vi.runOnlyPendingTimersAsync();
     vi.restoreAllMocks();
     vi.useRealTimers();
-  });
+  }, 15000); // 15 second timeout for cleanup
 
   it("retries and eventually succeeds", async () => {
     const fetchMock = vi

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -24,8 +24,16 @@ describe("fetchWithRetry", () => {
     vi.useFakeTimers();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
+
+    try {
+      await vi.runOnlyPendingTimersAsync();
+    } catch {
+      // no pending timers
+    }
+
+    vi.clearAllTimers();
     vi.useRealTimers();
   });
 

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -25,8 +25,8 @@ describe("fetchWithRetry", () => {
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("retries and eventually succeeds", async () => {

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithRetry, getRetryDelay } from "../../src/api/retry.js";
+
+function mockResponse(status: number, retryAfter?: string) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get(name: string) {
+        if (name.toLowerCase() === "retry-after") {
+          return retryAfter ?? null;
+        }
+
+        return null;
+      },
+    },
+    text: async () => "",
+    json: async () => ({}),
+  };
+}
+
+describe("fetchWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("retries and eventually succeeds", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockResponse(503) as never)
+      .mockResolvedValueOnce(mockResponse(200) as never);
+
+    const promise = fetchWithRetry("https://example.com");
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    const response = await promise;
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns final response after exhausting retries", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockResponse(503) as never)
+      .mockResolvedValueOnce(mockResponse(503) as never)
+      .mockResolvedValueOnce(mockResponse(503) as never);
+
+    const promise = fetchWithRetry("https://example.com");
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(400);
+
+    const response = await promise;
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("parses numeric Retry-After headers", () => {
+    const response = mockResponse(429, "2");
+
+    expect(getRetryDelay(response, 100)).toBe(2000);
+  });
+
+  it("parses HTTP-date Retry-After headers", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const response = mockResponse(429, "Thu, 01 Jan 2026 00:00:03 GMT");
+
+    expect(getRetryDelay(response, 100)).toBe(3000);
+  });
+
+  it("caps Retry-After delays to five seconds", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockResponse(429, "120") as never)
+      .mockResolvedValueOnce(mockResponse(200) as never);
+
+    const promise = fetchWithRetry("https://example.com");
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    const response = await promise;
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable responses", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(mockResponse(400) as never);
+
+    const response = await fetchWithRetry("https://example.com");
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchWithRetry, getRetryDelay } from "../../src/api/retry.js";
 
 function mockResponse(status: number, retryAfter?: string) {
@@ -7,11 +7,7 @@ function mockResponse(status: number, retryAfter?: string) {
     ok: status >= 200 && status < 300,
     headers: {
       get(name: string) {
-        if (name.toLowerCase() === "retry-after") {
-          return retryAfter ?? null;
-        }
-
-        return null;
+        return name.toLowerCase() === "retry-after" ? (retryAfter ?? null) : null;
       },
     },
     text: async () => "",
@@ -19,22 +15,33 @@ function mockResponse(status: number, retryAfter?: string) {
   };
 }
 
-describe("fetchWithRetry", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
+describe("getRetryDelay", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  afterEach(async () => {
+  it("parses numeric Retry-After headers", () => {
+    expect(getRetryDelay(mockResponse(429, "2"), 100)).toBe(2000);
+  });
+
+  it("parses HTTP-date Retry-After headers", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-01-01T00:00:00.000Z"));
+
+    expect(getRetryDelay(mockResponse(429, "Thu, 01 Jan 2026 00:00:03 GMT"), 100)).toBe(3000);
+  });
+
+  it("caps the delay at five seconds", () => {
+    expect(getRetryDelay(mockResponse(429, "120"), 100)).toBe(5000);
+  });
+
+  it("falls back when there is no Retry-After header", () => {
+    expect(getRetryDelay(mockResponse(503), 100)).toBe(100);
+  });
+});
+
+describe("fetchWithRetry", () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-
-    try {
-      await vi.runOnlyPendingTimersAsync();
-    } catch {
-      // no pending timers
-    }
-
-    vi.clearAllTimers();
-    vi.useRealTimers();
   });
 
   it("retries and eventually succeeds", async () => {
@@ -43,62 +50,19 @@ describe("fetchWithRetry", () => {
       .mockResolvedValueOnce(mockResponse(503) as never)
       .mockResolvedValueOnce(mockResponse(200) as never);
 
-    const promise = fetchWithRetry("https://example.com");
-
-    await vi.advanceTimersByTimeAsync(100);
-
-    const response = await promise;
+    const response = await fetchWithRetry("https://example.com");
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("returns final response after exhausting retries", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(mockResponse(503) as never)
-      .mockResolvedValueOnce(mockResponse(503) as never)
-      .mockResolvedValueOnce(mockResponse(503) as never);
+  it("returns the final response after exhausting retries", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse(503) as never);
 
-    const promise = fetchWithRetry("https://example.com");
-
-    await vi.advanceTimersByTimeAsync(100);
-    await vi.advanceTimersByTimeAsync(400);
-
-    const response = await promise;
+    const response = await fetchWithRetry("https://example.com");
 
     expect(response.status).toBe(503);
     expect(fetchMock).toHaveBeenCalledTimes(3);
-  });
-
-  it("parses numeric Retry-After headers", () => {
-    const response = mockResponse(429, "2");
-
-    expect(getRetryDelay(response, 100)).toBe(2000);
-  });
-
-  it("parses HTTP-date Retry-After headers", () => {
-    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-
-    const response = mockResponse(429, "Thu, 01 Jan 2026 00:00:03 GMT");
-
-    expect(getRetryDelay(response, 100)).toBe(3000);
-  });
-
-  it("caps Retry-After delays to five seconds", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(mockResponse(429, "120") as never)
-      .mockResolvedValueOnce(mockResponse(200) as never);
-
-    const promise = fetchWithRetry("https://example.com");
-
-    await vi.advanceTimersByTimeAsync(5000);
-
-    const response = await promise;
-
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not retry non-retryable responses", async () => {

--- a/tests/api/retry.test.ts
+++ b/tests/api/retry.test.ts
@@ -24,11 +24,10 @@ describe("fetchWithRetry", () => {
     vi.useFakeTimers();
   });
 
-  afterEach(async () => {
-    await vi.runOnlyPendingTimersAsync();
+  afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
-  }, 15000); // 15 second timeout for cleanup
+  });
 
   it("retries and eventually succeeds", async () => {
     const fetchMock = vi


### PR DESCRIPTION
## Fixes #43

### Summary

Implemented retry support with exponential backoff for API requests to improve resilience against transient failures.

### Changes

* Added a reusable `fetchWithRetry` helper
* Retries HTTP `429` (Too Many Requests) and `503` (Service Unavailable) responses
* Uses exponential backoff delays of:

  * 100ms (first retry)
  * 400ms (second retry)
* Honors `Retry-After` response headers when provided
* Applied retry logic to:

  * deps.dev API client
  * OSV API client

### Validation

Successfully passed all project checks:

```bash
pnpm lint
pnpm build
pnpm test
```

### Test Results

* 16 test files passed
* 123 tests passed
* 0 failures

