### PR TITLE
feat: Add Pipfile.lock parser for Python Pipenv projects

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -18,6 +18,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "Cargo.lock") return parseCargoLock(content);
   if (base === "go.sum") return parseGoSum(content);
   if (base === "Gemfile.lock") return parseGemfileLock(content);
+  if (base === "Pipfile.lock") return parsePipfileLock(content);
 
   return null;
 }
@@ -259,6 +260,31 @@ function parseGemfileLock(content: string): ParsedDep[] {
         }
         deps.push({ name: match[1], version, ecosystem: "rubygems" });
       }
+    }
+  }
+
+  return deps;
+}
+// ---------------------------------------------------------------------------
+// Pipfile.lock (Pipenv)
+// ---------------------------------------------------------------------------
+function parsePipfileLock(content: string): ParsedDep[] {
+  let json: Record<string, unknown>;
+  try {
+    json = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
+  const deps: ParsedDep[] = [];
+
+  for (const section of ["default", "develop"]) {
+    const packages = json[section] as Record<string, { version?: string }> | undefined;
+    if (!packages) continue;
+    for (const [name, val] of Object.entries(packages)) {
+      if (!val.version) continue;
+      const version = val.version.replace(/^==/, "");
+      deps.push({ name, version, ecosystem: "pypi" });
     }
   }
 

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -355,3 +355,56 @@ function parsePipfileLock(content: string): ParsedDep[] {
 
   return deps;
 }
+// ---------------------------------------------------------------------------
+// pubspec.lock (Dart/Flutter)
+// ---------------------------------------------------------------------------
+function parsePubspecLock(content: string): ParsedDep[] {
+  const deps: ParsedDep[] = [];
+  const lines = content.split("\n");
+
+  let inPackages = false;
+  let currentName: string | null = null;
+  let currentSource: string | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith("packages:")) {
+      inPackages = true;
+      continue;
+    }
+
+    if (line.startsWith("sdks:")) {
+      inPackages = false;
+      currentName = null;
+      currentSource = null;
+      continue;
+    }
+
+    if (!inPackages) continue;
+
+    const nameMatch = /^ {2}(\S+):/.exec(line);
+    if (nameMatch?.[1]) {
+      currentName = nameMatch[1];
+      currentSource = null;
+      continue;
+    }
+
+    if (!currentName) continue;
+
+    const sourceMatch = /^ {4}source:\s+"?([^\s"]+)"?/.exec(line);
+    if (sourceMatch?.[1]) {
+      currentSource = sourceMatch[1];
+      continue;
+    }
+
+    const versionMatch = /^ {4}version:\s+"?([^\s"]+)"?/.exec(line);
+    if (versionMatch?.[1]) {
+      if (currentSource !== "sdk") {
+        deps.push({ name: currentName, version: versionMatch[1], ecosystem: "pub" });
+      }
+      currentName = null;
+      currentSource = null;
+    }
+  }
+
+  return deps;
+}

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -21,13 +21,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock , Pipfile.lock",
           ),
       },
     },
@@ -39,7 +39,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
+              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported formats: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock`,
             },
           ],
         };

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -80,7 +80,7 @@ export function register(server: McpServer) {
         lockfile_name: z
           .string()
           .describe(
-            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
+            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock , Pipfile.lock",
           ),
         policy: z
           .enum(["permissive", "copyleft", "none"])
@@ -98,7 +98,7 @@ export function register(server: McpServer) {
           content: [
             {
               type: "text",
-              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock`,
+              text: `Unsupported lockfile format: ${lockfile_name}\n\nSupported: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock`,
             },
           ],
         };

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -235,7 +235,7 @@ describe("Pipfile.lock", () => {
       develop: {},
     });
     const result = parseLockfile("Pipfile.lock", content);
-    expect(result[0].version).toBe("1.24.0");
+    expect(result![0].version).toBe("1.24.0");
   });
 
   it("returns empty array for invalid JSON", () => {
@@ -253,7 +253,7 @@ describe("Pipfile.lock", () => {
     });
     const result = parseLockfile("Pipfile.lock", content);
     expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("flask");
+    expect(result![0].name).toBe("flask");
   });
 });
 
@@ -453,10 +453,6 @@ GEM
   });
   
 });
-
-// ---------------------------------------------------------------------------
-// pubspec.lock
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // pubspec.lock

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -235,7 +235,7 @@ describe("Pipfile.lock", () => {
       develop: {},
     });
     const result = parseLockfile("Pipfile.lock", content);
-    expect(result![0].version).toBe("1.24.0");
+    expect(result![0]!.version).toBe("1.24.0");
   });
 
   it("returns empty array for invalid JSON", () => {
@@ -253,7 +253,7 @@ describe("Pipfile.lock", () => {
     });
     const result = parseLockfile("Pipfile.lock", content);
     expect(result).toHaveLength(1);
-    expect(result![0].name).toBe("flask");
+    expect(result![0]!.name).toBe("flask");
   });
 });
 

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -235,7 +235,7 @@ describe("Pipfile.lock", () => {
       develop: {},
     });
     const result = parseLockfile("Pipfile.lock", content);
-    expect(result![0]!.version).toBe("1.24.0");
+    expect(result).toEqual([{ name: "numpy", version: "1.24.0", ecosystem: "pypi" }]);
   });
 
   it("returns empty array for invalid JSON", () => {
@@ -252,8 +252,7 @@ describe("Pipfile.lock", () => {
       develop: {},
     });
     const result = parseLockfile("Pipfile.lock", content);
-    expect(result).toHaveLength(1);
-    expect(result![0]!.name).toBe("flask");
+    expect(result).toEqual([{ name: "flask", version: "2.3.0", ecosystem: "pypi" }]);
   });
 });
 

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -207,6 +207,57 @@ describe("requirements.txt", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Pipfile.lock
+// ---------------------------------------------------------------------------
+
+describe("Pipfile.lock", () => {
+  it("extracts packages from default and develop sections", () => {
+    const content = JSON.stringify({
+      _meta: {},
+      default: {
+        requests: { version: "==2.28.0" },
+        flask: { version: "==2.3.0" },
+      },
+      develop: {
+        pytest: { version: "==7.4.0" },
+      },
+    });
+    const result = parseLockfile("Pipfile.lock", content);
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual({ name: "requests", version: "2.28.0", ecosystem: "pypi" });
+    expect(result).toContainEqual({ name: "flask", version: "2.3.0", ecosystem: "pypi" });
+    expect(result).toContainEqual({ name: "pytest", version: "7.4.0", ecosystem: "pypi" });
+  });
+
+  it("strips == prefix from versions", () => {
+    const content = JSON.stringify({
+      default: { numpy: { version: "==1.24.0" } },
+      develop: {},
+    });
+    const result = parseLockfile("Pipfile.lock", content);
+    expect(result[0].version).toBe("1.24.0");
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    const result = parseLockfile("Pipfile.lock", "not valid json {{{");
+    expect(result).toEqual([]);
+  });
+
+  it("skips entries with no version field", () => {
+    const content = JSON.stringify({
+      default: {
+        boto3: {},
+        flask: { version: "==2.3.0" },
+      },
+      develop: {},
+    });
+    const result = parseLockfile("Pipfile.lock", content);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("flask");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cargo.lock
 // ---------------------------------------------------------------------------
 
@@ -400,4 +451,5 @@ GEM
     expect(deps).toContainEqual({ name: "net-ssh", version: "7.0.1", ecosystem: "rubygems" });
     expect(deps).toContainEqual({ name: "i18n", version: "1.12.0", ecosystem: "rubygems" });
   });
+  
 });


### PR DESCRIPTION
## What does this PR do?
Adds a `parsePipfileLock()` function in `src/parsers/index.ts` that parses `Pipfile.lock` files from Python Pipenv projects and extracts package dependencies.

## Why?
Pipenv is a popular Python dependency manager. Without this parser, hound-mcp couldn't scan Pipenv-based projects for vulnerabilities.

## Type of change
- [ ] Bug fix
- [ ] New tool
- [x] New lockfile parser
- [ ] Improvement to existing tool
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist
- [ ] `pnpm check` passes (typecheck + lint + tests)
- [ ] New functionality has tests
- [ ] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed

## Testing
Verified the parser correctly:
- Extracts packages from both `default` and `develop` sections
- Strips `==` prefix from version strings
- Sets ecosystem to `pypi`
- Handles invalid JSON gracefully by returning empty array