### PR TITLE
chore: ignore .omo agent artifacts and ungroup dependabot majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+        # Keep major bumps out of the grouped PR so they get their own
+        # reviewable PR (a grouped TS 5->6 major broke CI in #58).
+        update-types:
+          - minor
+          - patch

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pnpm-debug.log*
 
 # Local planning docs
 hound-*.md
+
+# Agent session artifacts (e.g. accidentally committed in #75)
+.omo/


### PR DESCRIPTION
Two small repo-hygiene changes that came out of the current PR triage:

1. **Ignore `.omo/`** — agent session artifacts (`.omo/run-continuation/*.json`) were accidentally committed in #75. Ignoring the directory prevents recurrence.
2. **Ungroup Dependabot majors** — the `dev-dependencies` group now only batches `minor`/`patch`. A grouped TypeScript **5→6 major** rode along in #58 and broke `tsc --noEmit` (13 errors). Major dev-dep bumps will now arrive as their own reviewable PRs.

Refs #58, #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)