### PR TITLE
feat: add poetry.lock parser support

### DIFF
--- a/examples/audit-python-poetry/poetry.lock
+++ b/examples/audit-python-poetry/poetry.lock
@@ -1,0 +1,21 @@
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+python-versions = ">=3.7"
+
+[[package]]
+name = "urllib3"
+version = "2.0.4"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+python-versions = ">=3.8"
+
+[[package]]
+name = "certifi"
+version = "2023.7.22"
+description = "Python package for providing Mozilla's CA Bundle."
+python-versions = ">=3.6"
+
+[metadata]
+lock-version = "2.0"
+python-versions = "^3.11"

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -15,6 +15,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "yarn.lock") return parseYarnLock(content);
   if (base === "pnpm-lock.yaml") return parsePnpmLock(content);
   if (base === "requirements.txt") return parseRequirements(content);
+  if (base === "poetry.lock") return parsePoetryLock(content);
   if (base === "Cargo.lock") return parseCargoLock(content);
   if (base === "go.sum") return parseGoSum(content);
   if (base === "Gemfile.lock") return parseGemfileLock(content);
@@ -155,6 +156,39 @@ function parseRequirements(content: string): ParsedDep[] {
       deps.push({ name: eqMatch[1].toLowerCase(), version: eqMatch[2], ecosystem: "pypi" });
     }
   }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// poetry.lock (TOML)
+// ---------------------------------------------------------------------------
+function parsePoetryLock(content: string): ParsedDep[] {
+  const deps: ParsedDep[] = [];
+  let name: string | null = null;
+  let version: string | null = null;
+  let inPackage = false;
+
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (line === "[[package]]") {
+      if (name && version) deps.push({ name, version, ecosystem: "pypi" });
+      name = null;
+      version = null;
+      inPackage = true;
+    } else if (line.startsWith("[") && line.endsWith("]")) {
+      if (name && version) deps.push({ name, version, ecosystem: "pypi" });
+      name = null;
+      version = null;
+      inPackage = false;
+    } else if (inPackage) {
+      const nameMatch = /^name\s*=\s*"([^"]+)"/.exec(line);
+      if (nameMatch?.[1]) name = nameMatch[1];
+      const verMatch = /^version\s*=\s*"([^"]+)"/.exec(line);
+      if (verMatch?.[1]) version = verMatch[1];
+    }
+  }
+  if (name && version) deps.push({ name, version, ecosystem: "pypi" });
 
   return deps;
 }

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,13 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock",
           ),
       },
     },

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,21 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-<<<<<<< HEAD
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, or Gemfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
-=======
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
->>>>>>> upstream/main
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-<<<<<<< HEAD
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock",
-=======
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock , pubspec.lock , Pipfile.lock",
->>>>>>> upstream/main
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock",
           ),
       },
     },

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -81,7 +81,7 @@ export function register(server: McpServer) {
         lockfile_name: z
           .string()
           .describe(
-            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, Cargo.lock, go.sum, Gemfile.lock",
+            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock",
           ),
         policy: z
           .enum(["permissive", "copyleft", "none"])

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -325,7 +325,6 @@ describe("Pipfile.lock", () => {
     expect(result).toEqual([{ name: "flask", version: "2.3.0", ecosystem: "pypi" }]);
   });
 });
-});
 
 // ---------------------------------------------------------------------------
 // Cargo.lock

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -62,6 +62,23 @@ requests==2.31.0  # inline comment
 Flask==3.0.0
 `;
 
+const POETRY_LOCK = `[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+python-versions = ">=3.7"
+
+[[package]]
+name = "urllib3"
+version = "2.0.4"
+description = "HTTP library"
+python-versions = ">=3.8"
+
+[metadata]
+lock-version = "2.0"
+python-versions = "^3.11"
+`;
+
 const CARGO_LOCK = `[[package]]
 name = "serde"
 version = "1.0.188"
@@ -203,6 +220,61 @@ describe("requirements.txt", () => {
     expect(deps).toHaveLength(2);
     expect(deps).toContainEqual({ name: "requests", version: "2.31.0", ecosystem: "pypi" });
     expect(deps).toContainEqual({ name: "flask", version: "3.0.0", ecosystem: "pypi" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// poetry.lock
+// ---------------------------------------------------------------------------
+
+describe("poetry.lock", () => {
+  it("parses package blocks", () => {
+    const deps = parseLockfile("poetry.lock", POETRY_LOCK);
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "requests", version: "2.31.0", ecosystem: "pypi" });
+    expect(deps).toContainEqual({ name: "urllib3", version: "2.0.4", ecosystem: "pypi" });
+  });
+
+  it("returns empty array for empty content", () => {
+    expect(parseLockfile("poetry.lock", "")).toEqual([]);
+  });
+
+  it("skips incomplete package blocks without throwing", () => {
+    const content = `[[package]]
+name = "missing-version"
+
+[[package]]
+version = "1.0.0"
+
+[[package]]
+name = "complete"
+version = "2.0.0"
+`;
+    expect(() => parseLockfile("poetry.lock", content)).not.toThrow();
+    expect(parseLockfile("poetry.lock", content)).toEqual([
+      { name: "complete", version: "2.0.0", ecosystem: "pypi" },
+    ]);
+  });
+
+  it("ignores metadata section", () => {
+    const content = `[[package]]
+name = "requests"
+version = "2.31.0"
+
+[metadata]
+name = "not-a-package"
+version = "9.9.9"
+`;
+    expect(parseLockfile("poetry.lock", content)).toEqual([
+      { name: "requests", version: "2.31.0", ecosystem: "pypi" },
+    ]);
+  });
+
+  it("dispatches by basename", () => {
+    const deps = parseLockfile("/app/project/poetry.lock", POETRY_LOCK);
+    expect(deps).toHaveLength(2);
+    expect(deps).toContainEqual({ name: "requests", version: "2.31.0", ecosystem: "pypi" });
+    expect(deps).toContainEqual({ name: "urllib3", version: "2.0.4", ecosystem: "pypi" });
   });
 });
 


### PR DESCRIPTION
What does this PR do?

Adds support for parsing `poetry.lock` files in `parseLockfile()`.

It walks each `[[package]]` block, pulls out `name` and `version`, and maps them to the `pypi` ecosystem. `[metadata]` and malformed blocks are skipped instead of throwing.

For example:

[[package]]
name = "requests"
version = "2.31.0"

→ { name: "requests", version: "2.31.0", ecosystem: "pypi" }

Also updated the tool descriptions in `audit.ts` and `license-check.ts`, and added tests for normal parsing, empty input, malformed blocks, and dispatch.

Closes #59