### PR TITLE
fix: handle affected entries missing package on CVE-alias lookups

### DIFF
--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -38,7 +38,9 @@ export interface OsvRange {
 }
 
 export interface OsvAffected {
-  package: {
+  // Some OSV records — notably CVE-alias lookups, as opposed to native
+  // OSV/GHSA IDs — omit `package` entirely on one or more `affected` entries.
+  package?: {
     name: string;
     ecosystem: string;
     purl?: string;
@@ -215,7 +217,7 @@ export function extractFixVersions(vuln: OsvVuln, ecosystem: Ecosystem): string[
   const fixed = new Set<string>();
 
   for (const affected of vuln.affected) {
-    if (affected.package.ecosystem.toLowerCase() !== osvEcosystem.toLowerCase()) {
+    if (affected.package?.ecosystem.toLowerCase() !== osvEcosystem.toLowerCase()) {
       continue;
     }
     for (const range of affected.ranges) {

--- a/src/tools/advisories.ts
+++ b/src/tools/advisories.ts
@@ -50,7 +50,13 @@ export function register(server: McpServer) {
           lines.push("─".repeat(30));
 
           for (const affected of vuln.affected) {
-            lines.push(`  ${affected.package.ecosystem}: ${affected.package.name}`);
+            // Some OSV records — notably CVE-alias lookups — omit `package`
+            // on one or more `affected` entries. Fall back to a generic
+            // label rather than crashing on the missing field.
+            const label = affected.package
+              ? `${affected.package.ecosystem}: ${affected.package.name}`
+              : "(package details unavailable)";
+            lines.push(`  ${label}`);
 
             for (const range of affected.ranges) {
               if (range.type === "SEMVER") {

--- a/tests/api/osv.test.ts
+++ b/tests/api/osv.test.ts
@@ -291,6 +291,25 @@ describe("extractFixVersions", () => {
     const versions = extractFixVersions(vuln, "npm");
     expect(versions.filter((v) => v === "4.19.2")).toHaveLength(1);
   });
+
+  it("skips affected entries missing `package` instead of throwing", () => {
+    // Regression test for #14: CVE-alias lookups can return `affected`
+    // entries without a `package` object.
+    const vuln: OsvVuln = {
+      ...VULN_FIXTURE,
+      affected: [
+        {
+          ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "4.19.2" }] }],
+        } as OsvVuln["affected"][number],
+        {
+          package: { name: "express", ecosystem: "npm" },
+          ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "4.19.3" }] }],
+        },
+      ],
+    };
+    expect(() => extractFixVersions(vuln, "npm")).not.toThrow();
+    expect(extractFixVersions(vuln, "npm")).toEqual(["4.19.3"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/tools/advisories.test.ts
+++ b/tests/tools/advisories.test.ts
@@ -108,4 +108,29 @@ describe("hound_advisories", () => {
     const text = getText(result);
     expect(text).toContain("github.com/expressjs/express/security/advisories");
   });
+
+  it("does not crash when a CVE-alias lookup omits `package` on an affected entry", async () => {
+    // Regression test for #14: OSV's CVE-alias responses may return
+    // `affected` entries without a `package` object, unlike native
+    // GHSA/OSV ID lookups.
+    const CVE_FIXTURE: OsvVuln = {
+      ...OSV_FIXTURE,
+      id: "CVE-2024-29041",
+      affected: [
+        {
+          ranges: [{ type: "SEMVER", events: [{ introduced: "0" }, { fixed: "4.19.2" }] }],
+        } as OsvVuln["affected"][number],
+      ],
+    };
+    vi.mocked(osv.getVuln).mockResolvedValue(CVE_FIXTURE);
+    vi.mocked(depsdev.getAdvisory).mockResolvedValue(DEPSDEV_ADVISORY_FIXTURE);
+
+    const result = await (
+      tool.handler as (args: Record<string, unknown>, extra?: unknown) => Promise<unknown>
+    )({ id: "CVE-2024-29041" });
+    const text = getText(result);
+    expect(text).toContain("CVE-2024-29041");
+    expect(text).toContain("(package details unavailable)");
+    expect(text).toContain("fixed in 4.19.2");
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes `hound_advisories` crashing with `Cannot read properties of undefined (reading 'ecosystem')` when looking up an advisory by CVE ID (e.g. `CVE-2024-29041`).

## Why?

OSV's `affected[]` entries omit the `package` object for some CVE-alias lookups, unlike native GHSA/OSV ID lookups (confirmed by comparing the two in the issue). `hound_advisories` and `extractFixVersions` in `src/api/osv.ts` both assumed `package` was always present and dereferenced it unconditionally.

`OsvAffected.package` is now typed as optional (matching the real API shape) and both call sites are guarded:
- `extractFixVersions` uses optional chaining to skip entries without a `package` instead of throwing.
- `hound_advisories`'s display logic falls back to `(package details unavailable)` instead of crashing, while still showing the range/fix-version info for that entry.

## Type of change

- [x] Bug fix

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed — not needed, no architectural change

## Testing

Added two regression tests reproducing the exact reported scenario (a CVE lookup whose `affected` entry has no `package`):
- `tests/api/osv.test.ts` — `extractFixVersions` skips the entry instead of throwing, and still returns fix versions from other entries.
- `tests/tools/advisories.test.ts` — `hound_advisories` renders `(package details unavailable)` and the fix-version line instead of crashing.

Full suite: 148 passed (146 existing + 2 new). `pnpm check` clean.

Fixes #14