### PR TITLE
feat: add packages.lock.json parser for NuGet/.NET projects

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub";
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub" | "nuget";
 }
 
 /**
@@ -21,6 +21,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "Gemfile.lock") return parseGemfileLock(content);
   if (base === "Pipfile.lock") return parsePipfileLock(content);
   if (base === "pubspec.lock") return parsePubspecLock(content);
+  if (base === "packages.lock.json") return parseNuGetLock(content);
 
   return null;
 }
@@ -435,6 +436,43 @@ function parsePubspecLock(content: string): ParsedDep[] {
       }
       currentName = null;
       currentSource = null;
+    }
+  }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// packages.lock.json (NuGet)
+// ---------------------------------------------------------------------------
+function parseNuGetLock(content: string): ParsedDep[] {
+  let json: Record<string, unknown>;
+
+  try {
+    json = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
+  const deps: ParsedDep[] = [];
+
+  // "dependencies" is a map of target-framework (e.g. "net8.0") to a map of
+  // package name -> { resolved, type, contentHash, ... }
+  const targets = json.dependencies as
+    | Record<string, Record<string, { resolved?: string }>>
+    | undefined;
+
+  if (!targets) return deps;
+
+  for (const packages of Object.values(targets)) {
+    for (const [name, val] of Object.entries(packages)) {
+      if (!val.resolved) continue;
+
+      deps.push({
+        name,
+        version: val.resolved,
+        ecosystem: "nuget",
+      });
     }
   }
 

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,13 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, or packages.lock.json and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, packages.lock.json",
           ),
       },
     },

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -88,7 +88,7 @@ export function register(server: McpServer) {
         lockfile_name: z
           .string()
           .describe(
-            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock",
+            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock, packages.lock.json",
           ),
 
         policy: z

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -327,6 +327,84 @@ describe("Pipfile.lock", () => {
 });
 
 // ---------------------------------------------------------------------------
+// packages.lock.json (NuGet)
+// ---------------------------------------------------------------------------
+
+describe("packages.lock.json", () => {
+  it("extracts packages from a single target framework", () => {
+    const content = JSON.stringify({
+      version: 1,
+      dependencies: {
+        "net8.0": {
+          "Newtonsoft.Json": {
+            type: "Direct",
+            requested: "[13.0.1, )",
+            resolved: "13.0.1",
+            contentHash: "abc123",
+          },
+          Serilog: {
+            type: "Direct",
+            requested: "[3.1.1, )",
+            resolved: "3.1.1",
+            contentHash: "def456",
+          },
+        },
+      },
+    });
+    const result = parseLockfile("packages.lock.json", content);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      name: "Newtonsoft.Json",
+      version: "13.0.1",
+      ecosystem: "nuget",
+    });
+    expect(result).toContainEqual({ name: "Serilog", version: "3.1.1", ecosystem: "nuget" });
+  });
+
+  it("extracts packages across multiple target frameworks", () => {
+    const content = JSON.stringify({
+      version: 1,
+      dependencies: {
+        "net6.0": {
+          "Newtonsoft.Json": { type: "Direct", resolved: "13.0.1" },
+        },
+        "net8.0": {
+          "Newtonsoft.Json": { type: "Direct", resolved: "13.0.1" },
+          Serilog: { type: "Direct", resolved: "3.1.1" },
+        },
+      },
+    });
+    const result = parseLockfile("packages.lock.json", content);
+    expect(result).toHaveLength(3);
+    expect(result?.filter((d) => d.name === "Newtonsoft.Json")).toHaveLength(2);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    const result = parseLockfile("packages.lock.json", "not valid json {{{");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when dependencies field is missing", () => {
+    const result = parseLockfile("packages.lock.json", JSON.stringify({ version: 1 }));
+    expect(result).toEqual([]);
+  });
+
+  it("skips entries with no resolved field", () => {
+    const content = JSON.stringify({
+      version: 1,
+      dependencies: {
+        "net8.0": {
+          Transitive: { type: "Transitive" },
+          Serilog: { type: "Direct", resolved: "3.1.1" },
+        },
+      },
+    });
+    const result = parseLockfile("packages.lock.json", content);
+    expect(result).toEqual([{ name: "Serilog", version: "3.1.1", ecosystem: "nuget" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cargo.lock
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Adds support for NuGet's `packages.lock.json` format (.NET projects) — a new lockfile parser plus tool-description updates so `hound_audit` and `hound_license_check` advertise it.

## Why?

We support npm, pip/poetry/pipenv, Cargo, Go, RubyGems, and Dart, but not NuGet — a major ecosystem, and both OSV (`NuGet`) and deps.dev (`nuget`) already support it on the data side.

## Type of change

- [x] New lockfile parser

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed — not needed, follows the existing parser pattern exactly

## Testing

Added 5 tests in `tests/parsers/index.test.ts` covering: single target framework, multiple target frameworks (with dedup-relevant overlap), invalid JSON, missing `dependencies` field, and entries missing `resolved`.

`nuget` was already present in `ECOSYSTEM_VALUES` and mapped in both `src/api/depsdev.ts` and `src/api/osv.ts`, so this PR only adds the parser (`parseNuGetLock`) and the two tool-description strings — no changes needed to the ecosystem plumbing.

Full suite: 173 passed (168 existing + 5 new). `pnpm check` clean.

Fixes #94