### PR TITLE
feat: add composer.lock parser for PHP/Composer projects

### DIFF
--- a/src/api/osv.ts
+++ b/src/api/osv.ts
@@ -21,6 +21,7 @@ const ECOSYSTEM_MAP: Record<Ecosystem, string> = {
   nuget: "NuGet",
   rubygems: "RubyGems",
   pub: "Pub",
+  packagist: "Packagist",
 };
 
 export interface OsvSeverityEntry {

--- a/src/constants/ecosystems.ts
+++ b/src/constants/ecosystems.ts
@@ -7,4 +7,5 @@ export const ECOSYSTEM_VALUES = [
   "nuget",
   "rubygems",
   "pub",
+  "packagist",
 ] as const;

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub";
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub" | "packagist";
 }
 
 /**
@@ -21,6 +21,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "Gemfile.lock") return parseGemfileLock(content);
   if (base === "Pipfile.lock") return parsePipfileLock(content);
   if (base === "pubspec.lock") return parsePubspecLock(content);
+  if (base === "composer.lock") return parseComposerLock(content);
 
   return null;
 }
@@ -435,6 +436,38 @@ function parsePubspecLock(content: string): ParsedDep[] {
       }
       currentName = null;
       currentSource = null;
+    }
+  }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// composer.lock (PHP/Composer)
+// ---------------------------------------------------------------------------
+function parseComposerLock(content: string): ParsedDep[] {
+  let json: Record<string, unknown>;
+
+  try {
+    json = JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
+  const deps: ParsedDep[] = [];
+
+  for (const section of ["packages", "packages-dev"]) {
+    const entries = json[section] as { name?: string; version?: string }[] | undefined;
+    if (!entries) continue;
+
+    for (const entry of entries) {
+      if (!entry.name || !entry.version) continue;
+
+      deps.push({
+        name: entry.name,
+        version: entry.version.replace(/^v/, ""),
+        ecosystem: "packagist",
+      });
     }
   }
 

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,13 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, or composer.lock and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, composer.lock",
           ),
       },
     },

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -83,8 +83,9 @@ export function register(server: McpServer) {
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
 
-        // pubspec.lock is intentionally omitted here because deps.dev does not
-        // support the Pub ecosystem. The handler below returns an explicit message.
+        // pubspec.lock and composer.lock are intentionally omitted here because
+        // deps.dev does not support the Pub or Packagist ecosystems. The handler
+        // below returns an explicit message for both.
         lockfile_name: z
           .string()
           .describe(
@@ -120,6 +121,18 @@ export function register(server: McpServer) {
             {
               type: "text",
               text: "License checking for pubspec.lock is not currently supported because deps.dev does not support the Pub ecosystem.",
+            },
+          ],
+        };
+      }
+
+      // Same limitation for Packagist (composer.lock) — deps.dev has no PHP ecosystem support.
+      if (deps.some((dep) => dep.ecosystem === "packagist")) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "License checking for composer.lock is not currently supported because deps.dev does not support the Packagist ecosystem.",
             },
           ],
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,16 @@
 // Ecosystems
 // ---------------------------------------------------------------------------
 
-export type Ecosystem = "npm" | "pypi" | "go" | "maven" | "cargo" | "nuget" | "rubygems" | "pub";
+export type Ecosystem =
+  | "npm"
+  | "pypi"
+  | "go"
+  | "maven"
+  | "cargo"
+  | "nuget"
+  | "rubygems"
+  | "pub"
+  | "packagist";
 
 // ---------------------------------------------------------------------------
 // Parsed dependency (output of lockfile parsers)

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -600,3 +600,70 @@ sdks:
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// composer.lock (PHP/Composer)
+// ---------------------------------------------------------------------------
+
+describe("composer.lock", () => {
+  it("extracts packages from both packages and packages-dev", () => {
+    const content = JSON.stringify({
+      packages: [
+        { name: "laravel/framework", version: "v10.0.0" },
+        { name: "guzzlehttp/guzzle", version: "7.5.0" },
+      ],
+      "packages-dev": [{ name: "phpunit/phpunit", version: "10.0.0" }],
+    });
+    const result = parseLockfile("composer.lock", content);
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual({
+      name: "laravel/framework",
+      version: "10.0.0",
+      ecosystem: "packagist",
+    });
+    expect(result).toContainEqual({
+      name: "guzzlehttp/guzzle",
+      version: "7.5.0",
+      ecosystem: "packagist",
+    });
+    expect(result).toContainEqual({
+      name: "phpunit/phpunit",
+      version: "10.0.0",
+      ecosystem: "packagist",
+    });
+  });
+
+  it("strips leading v from version strings", () => {
+    const content = JSON.stringify({
+      packages: [{ name: "laravel/framework", version: "v10.0.0" }],
+    });
+    const result = parseLockfile("composer.lock", content);
+    expect(result).toEqual([
+      { name: "laravel/framework", version: "10.0.0", ecosystem: "packagist" },
+    ]);
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    const result = parseLockfile("composer.lock", "not valid json {{{");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when neither packages nor packages-dev is present", () => {
+    const result = parseLockfile("composer.lock", JSON.stringify({ "content-hash": "abc" }));
+    expect(result).toEqual([]);
+  });
+
+  it("skips entries missing name or version", () => {
+    const content = JSON.stringify({
+      packages: [
+        { name: "laravel/framework" },
+        { version: "1.0.0" },
+        { name: "guzzlehttp/guzzle", version: "7.5.0" },
+      ],
+    });
+    const result = parseLockfile("composer.lock", content);
+    expect(result).toEqual([
+      { name: "guzzlehttp/guzzle", version: "7.5.0", ecosystem: "packagist" },
+    ]);
+  });
+});

--- a/tests/tools/audit.test.ts
+++ b/tests/tools/audit.test.ts
@@ -65,6 +65,23 @@ describe("hound_audit", () => {
     expect(text).toContain("GHSA-critical");
   });
 
+  it("parses composer.lock and reports clean", async () => {
+    vi.mocked(osv.queryVulnsBatch).mockResolvedValue([[]]);
+
+    const content = JSON.stringify({
+      packages: [{ name: "laravel/framework", version: "v10.0.0" }],
+    });
+
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: content,
+      lockfile_name: "composer.lock",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("Hound Audit Report");
+    expect(text).toContain("No known vulnerabilities");
+  });
+
   it("parses requirements.txt and reports clean", async () => {
     vi.mocked(osv.queryVulnsBatch).mockResolvedValue([[], []]);
 
@@ -81,7 +98,7 @@ describe("hound_audit", () => {
   it("returns error for unsupported lockfile format", async () => {
     const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
       lockfile_content: "{}",
-      lockfile_name: "composer.lock",
+      lockfile_name: "bower.json",
     });
 
     const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";

--- a/tests/tools/license-check.test.ts
+++ b/tests/tools/license-check.test.ts
@@ -65,12 +65,29 @@ describe("hound_license_check", () => {
   it("handles unsupported lockfile format", async () => {
     const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
       lockfile_content: "{}",
-      lockfile_name: "composer.lock",
+      lockfile_name: "bower.json",
       policy: "permissive",
     });
 
     const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
     expect(text).toContain("Unsupported lockfile format");
+  });
+
+  it("returns an explicit message for composer.lock instead of checking licenses", async () => {
+    const content = JSON.stringify({
+      packages: [{ name: "laravel/framework", version: "v10.0.0" }],
+    });
+
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: content,
+      lockfile_name: "composer.lock",
+      policy: "permissive",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("not currently supported");
+    expect(text).toContain("Packagist");
+    expect(depsdev.getVersion).not.toHaveBeenCalled();
   });
 
   it("suggests a similar supported lockfile format", async () => {


### PR DESCRIPTION
## What does this PR do?

Adds support for Composer's `composer.lock` format (PHP/Laravel/Symfony projects) — a new lockfile parser plus tool-description updates.

## Why?

Composer is the standard PHP package manager; this enables vulnerability scanning for PHP/Laravel/Symfony projects via `hound_audit`.

## Type of change

- [x] New lockfile parser

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed — not needed, follows the existing parser pattern

## Implementation notes

Unlike a couple of the other recent parser additions, `packagist` wasn't wired into the ecosystem system at all yet, so this PR:

- Adds `"packagist"` to `Ecosystem` (`src/types/index.ts`), `ECOSYSTEM_VALUES`, and OSV's `ECOSYSTEM_MAP` (`packagist: "Packagist"` — OSV does support Packagist, confirmed against the live API).
- **Does not** add it to `src/api/depsdev.ts`'s `ECOSYSTEM_MAP`. I checked deps.dev's live API directly (`api.deps.dev/v3/systems/PACKAGIST/...`) and it returns the same 404 as a made-up system name — deps.dev has no PHP/Packagist support. This mirrors the existing Pub/Dart precedent in the codebase, so `hound_license_check` now returns an explicit "not currently supported" message for `composer.lock` (same pattern as `pubspec.lock`) instead of silently failing, while `hound_audit` works end-to-end via OSV.
- Two pre-existing tests (`audit.test.ts`, `license-check.test.ts`) used `composer.lock` as their "unsupported format" example — swapped those to `bower.json` since that's no longer true.

## Testing

Added tests for: packages + packages-dev extraction, `v` version-prefix stripping, invalid JSON, missing fields, entries missing name/version, a full `hound_audit` pass, and the `hound_license_check` unsupported-ecosystem message.

Full suite: 175 passed. `pnpm check` clean.

Fixes #60