### PR TITLE
docs: add lockfile parser contribution checklist (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,11 +150,6 @@ See the ["Adding a Lockfile Parser" checklist in CONTRIBUTING.md](./CONTRIBUTING
 
 ---
 
-## Adding a Lockfile Parser
-
-See the ["Adding a Lockfile Parser" checklist in CONTRIBUTING.md](./CONTRIBUTING.md#adding-a-lockfile-parser) — it covers `src/parsers/index.ts`, `src/constants/ecosystems.ts`, the tool descriptions in `src/tools/audit.ts` / `src/tools/license-check.ts`, and test coverage in `tests/parsers/index.test.ts`.
-
----
 
 ## Adding a New API Client
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,18 @@ export function register(server: McpServer) {
 
 ---
 
+## Adding a Lockfile Parser
+
+See the ["Adding a Lockfile Parser" checklist in CONTRIBUTING.md](./CONTRIBUTING.md#adding-a-lockfile-parser) — it covers `src/parsers/index.ts`, `src/constants/ecosystems.ts`, the tool descriptions in `src/tools/audit.ts` / `src/tools/license-check.ts`, and test coverage in `tests/parsers/index.test.ts`.
+
+---
+
+## Adding a Lockfile Parser
+
+See the ["Adding a Lockfile Parser" checklist in CONTRIBUTING.md](./CONTRIBUTING.md#adding-a-lockfile-parser) — it covers `src/parsers/index.ts`, `src/constants/ecosystems.ts`, the tool descriptions in `src/tools/audit.ts` / `src/tools/license-check.ts`, and test coverage in `tests/parsers/index.test.ts`.
+
+---
+
 ## Adding a New API Client
 
 If a new free, unauthenticated data source is needed:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,22 +113,6 @@ Run `pnpm check` before opening the PR — it catches most of the above automati
 
 ---
 
-## Adding a Lockfile Parser
-
-Nearly every parser PR misses a step — tests, tool descriptions, or the ecosystem enum — which costs a review round-trip. Work through this checklist:
-
-1. **Write the parser** — add a `parseXxx()` function in `src/parsers/index.ts` and wire it into the `parseLockfile()` dispatcher (matched by filename, e.g. `"go.sum"`, `"Cargo.lock"`).
-2. **Register the ecosystem** — if the format introduces a new package ecosystem, add it to `ECOSYSTEM_VALUES` in `src/constants/ecosystems.ts`.
-3. **Update tool descriptions** — add the new filename to the supported-format lists in both `src/tools/audit.ts` and `src/tools/license-check.ts` (the tool `description` field and the `lockfile_name` input schema description).
-4. **Add tests** — add a `describe()` block for the format in `tests/parsers/index.test.ts` covering:
-   - the happy path, with a realistic (trimmed) lockfile fixture parsing into the expected deps
-   - invalid or malformed input returning `[]`
-5. **Optional: add an example** — add a project under `examples/` that demonstrates `hound_audit` or `hound_license_check` against the new format, and link it from `examples/README.md`.
-
-Run `pnpm check` before opening the PR — it catches most of the above automatically (typecheck + lint + tests).
-
----
-
 ## Code Style
 
 - TypeScript strict mode — no `any`, ever

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,38 @@ export function register(server: McpServer) {
 
 ---
 
+## Adding a Lockfile Parser
+
+Nearly every parser PR misses a step — tests, tool descriptions, or the ecosystem enum — which costs a review round-trip. Work through this checklist:
+
+1. **Write the parser** — add a `parseXxx()` function in `src/parsers/index.ts` and wire it into the `parseLockfile()` dispatcher (matched by filename, e.g. `"go.sum"`, `"Cargo.lock"`).
+2. **Register the ecosystem** — if the format introduces a new package ecosystem, add it to `ECOSYSTEM_VALUES` in `src/constants/ecosystems.ts`.
+3. **Update tool descriptions** — add the new filename to the supported-format lists in both `src/tools/audit.ts` and `src/tools/license-check.ts` (the tool `description` field and the `lockfile_name` input schema description).
+4. **Add tests** — add a `describe()` block for the format in `tests/parsers/index.test.ts` covering:
+   - the happy path, with a realistic (trimmed) lockfile fixture parsing into the expected deps
+   - invalid or malformed input returning `[]`
+5. **Optional: add an example** — add a project under `examples/` that demonstrates `hound_audit` or `hound_license_check` against the new format, and link it from `examples/README.md`.
+
+Run `pnpm check` before opening the PR — it catches most of the above automatically (typecheck + lint + tests).
+
+---
+
+## Adding a Lockfile Parser
+
+Nearly every parser PR misses a step — tests, tool descriptions, or the ecosystem enum — which costs a review round-trip. Work through this checklist:
+
+1. **Write the parser** — add a `parseXxx()` function in `src/parsers/index.ts` and wire it into the `parseLockfile()` dispatcher (matched by filename, e.g. `"go.sum"`, `"Cargo.lock"`).
+2. **Register the ecosystem** — if the format introduces a new package ecosystem, add it to `ECOSYSTEM_VALUES` in `src/constants/ecosystems.ts`.
+3. **Update tool descriptions** — add the new filename to the supported-format lists in both `src/tools/audit.ts` and `src/tools/license-check.ts` (the tool `description` field and the `lockfile_name` input schema description).
+4. **Add tests** — add a `describe()` block for the format in `tests/parsers/index.test.ts` covering:
+   - the happy path, with a realistic (trimmed) lockfile fixture parsing into the expected deps
+   - invalid or malformed input returning `[]`
+5. **Optional: add an example** — add a project under `examples/` that demonstrates `hound_audit` or `hound_license_check` against the new format, and link it from `examples/README.md`.
+
+Run `pnpm check` before opening the PR — it catches most of the above automatically (typecheck + lint + tests).
+
+---
+
 ## Code Style
 
 - TypeScript strict mode — no `any`, ever


### PR DESCRIPTION
New contributors adding lockfile support often miss a step, since the process wasn't documented anywhere. This adds a checklist to CONTRIBUTING.md covering every touchpoint:
- Add a `parse()` function and wire it into the `parseLockfile()` dispatcher in `src/parsers/index.ts`
- Register new ecosystems in `ECOSYSTEM_VALUES` (`src/constants/ecosystems.ts`)
- Update the supported-format strings in `src/tools/audit.ts` and `src/tools/license-check.ts`
- Add a `describe()` block in `tests/parsers/index.test.ts` covering the happy path and malformed input
- Optionally add a usage example under `examples/`
Also cross-linked from CLAUDE.md so it's discoverable from either doc.
Closes #95