### PR TITLE
feat: add gradle.lockfile parser for Gradle/Java projects

### DIFF
--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,7 +1,7 @@
 export interface ParsedDep {
   name: string;
   version: string;
-  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub";
+  ecosystem: "npm" | "pypi" | "cargo" | "go" | "rubygems" | "pub" | "maven";
 }
 
 /**
@@ -21,6 +21,7 @@ export function parseLockfile(filename: string, content: string): ParsedDep[] | 
   if (base === "Gemfile.lock") return parseGemfileLock(content);
   if (base === "Pipfile.lock") return parsePipfileLock(content);
   if (base === "pubspec.lock") return parsePubspecLock(content);
+  if (base === "gradle.lockfile") return parseGradleLockfile(content);
 
   return null;
 }
@@ -436,6 +437,36 @@ function parsePubspecLock(content: string): ParsedDep[] {
       currentName = null;
       currentSource = null;
     }
+  }
+
+  return deps;
+}
+
+// ---------------------------------------------------------------------------
+// gradle.lockfile (Gradle/Java, single-file dependency locking format)
+// ---------------------------------------------------------------------------
+function parseGradleLockfile(content: string): ParsedDep[] {
+  const deps: ParsedDep[] = [];
+
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+
+    // Comment lines and metadata lines (e.g. "empty=testCompileClasspath")
+    // carry no dependency coordinate — skip them.
+    if (!line || line.startsWith("#") || line.startsWith("empty=")) continue;
+
+    // <group>:<artifact>:<version>=<comma-separated configurations>
+    const match = /^([^:=]+):([^:=]+):([^:=]+)=/.exec(line);
+    if (!match) continue;
+
+    const [, group, artifact, version] = match;
+    if (!group || !artifact || !version) continue;
+
+    deps.push({
+      name: `${group}:${artifact}`,
+      version,
+      ecosystem: "maven",
+    });
   }
 
   return deps;

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -22,13 +22,13 @@ export function register(server: McpServer) {
     "hound_audit",
     {
       description:
-        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, or Pipfile.lock and batch-queries OSV for vulnerabilities across all dependencies.",
+        "Scan a project's lockfile for dependency risks. Parses package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, or gradle.lockfile and batch-queries OSV for vulnerabilities across all dependencies.",
       inputSchema: {
         lockfile_content: z.string().describe("Full text content of the lockfile"),
         lockfile_name: z
           .string()
           .describe(
-            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock",
+            "Filename to determine format: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, pubspec.lock, Pipfile.lock, gradle.lockfile",
           ),
       },
     },

--- a/src/tools/license-check.ts
+++ b/src/tools/license-check.ts
@@ -88,7 +88,7 @@ export function register(server: McpServer) {
         lockfile_name: z
           .string()
           .describe(
-            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock",
+            "Filename: package-lock.json, yarn.lock, pnpm-lock.yaml, requirements.txt, poetry.lock, Cargo.lock, go.sum, Gemfile.lock, Pipfile.lock, gradle.lockfile",
           ),
 
         policy: z

--- a/tests/parsers/index.test.ts
+++ b/tests/parsers/index.test.ts
@@ -600,3 +600,60 @@ sdks:
     ]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// gradle.lockfile (Gradle/Java)
+// ---------------------------------------------------------------------------
+
+describe("gradle.lockfile", () => {
+  it("extracts dependencies from a typical lockfile", () => {
+    const content = `# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+com.google.guava:guava:31.1-jre=compileClasspath,runtimeClasspath
+org.springframework:spring-core:5.3.20=compileClasspath
+empty=annotationProcessor,testCompileClasspath
+`;
+    const result = parseLockfile("gradle.lockfile", content);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      name: "com.google.guava:guava",
+      version: "31.1-jre",
+      ecosystem: "maven",
+    });
+    expect(result).toContainEqual({
+      name: "org.springframework:spring-core",
+      version: "5.3.20",
+      ecosystem: "maven",
+    });
+  });
+
+  it("skips comment lines", () => {
+    const content = `# comment one
+# comment two
+com.example:lib:1.0.0=compileClasspath
+`;
+    const result = parseLockfile("gradle.lockfile", content);
+    expect(result).toEqual([{ name: "com.example:lib", version: "1.0.0", ecosystem: "maven" }]);
+  });
+
+  it("skips the empty= metadata line", () => {
+    const content = `empty=annotationProcessor,testCompileClasspath\n`;
+    const result = parseLockfile("gradle.lockfile", content);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array for blank content", () => {
+    const result = parseLockfile("gradle.lockfile", "");
+    expect(result).toEqual([]);
+  });
+
+  it("ignores malformed lines that don't match group:artifact:version=", () => {
+    const content = `not-a-valid-line
+com.example:lib:1.0.0=compileClasspath
+another:malformed
+`;
+    const result = parseLockfile("gradle.lockfile", content);
+    expect(result).toEqual([{ name: "com.example:lib", version: "1.0.0", ecosystem: "maven" }]);
+  });
+});

--- a/tests/tools/audit.test.ts
+++ b/tests/tools/audit.test.ts
@@ -65,6 +65,21 @@ describe("hound_audit", () => {
     expect(text).toContain("GHSA-critical");
   });
 
+  it("parses gradle.lockfile and reports clean", async () => {
+    vi.mocked(osv.queryVulnsBatch).mockResolvedValue([[]]);
+
+    const content = "com.google.guava:guava:31.1-jre=compileClasspath\n";
+
+    const result = await (tool.handler as (args: Record<string, unknown>) => Promise<unknown>)({
+      lockfile_content: content,
+      lockfile_name: "gradle.lockfile",
+    });
+
+    const text = (result as { content: { text: string }[] }).content[0]?.text ?? "";
+    expect(text).toContain("Hound Audit Report");
+    expect(text).toContain("No known vulnerabilities");
+  });
+
   it("parses requirements.txt and reports clean", async () => {
     vi.mocked(osv.queryVulnsBatch).mockResolvedValue([[], []]);
 


### PR DESCRIPTION
## What does this PR do?

Adds support for Gradle's single-file dependency locking format (`gradle.lockfile`) — a new lockfile parser plus tool-description updates.

## Why?

Enables vulnerability scanning for Gradle-based Java/Android/Kotlin projects via `hound_audit`.

## Type of change

- [x] New lockfile parser

## Checklist

- [x] `pnpm check` passes (typecheck + lint + tests)
- [x] New functionality has tests
- [x] Tool output is human-readable text (not raw JSON)
- [x] No new dependencies that require API keys or accounts
- [ ] CLAUDE.md updated if architecture changed — not needed, follows the existing parser pattern

## Implementation notes

Format is `<group>:<artifact>:<version>=<comma-separated configurations>`, one dependency per line, e.g.:

```
com.google.guava:guava:31.1-jre=compileClasspath,runtimeClasspath
empty=annotationProcessor,testCompileClasspath
```

Comment lines (`#`) and the `empty=` metadata line (lists configurations with nothing locked, not a dependency) are skipped. `name` is set to `group:artifact` (standard Maven coordinate form), `ecosystem: "maven"` — which was already fully wired into `Ecosystem`, `ECOSYSTEM_VALUES`, and both API clients, so this PR only adds the parser and doc updates, same shape as the recently-merged NuGet parser.

## Testing

Added tests for: typical multi-dependency lockfile, comment-line skipping, `empty=` line skipping, blank content, malformed lines, and a full `hound_audit` pass.

Full suite: 174 passed. `pnpm check` clean.

Fixes #33